### PR TITLE
feat: add CSS selectors guide page with examples and theory

### DIFF
--- a/CSS/selectors.css
+++ b/CSS/selectors.css
@@ -1,0 +1,183 @@
+/* Universal Selector (*) */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* Type Selector */
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  padding: 2.5rem 1.25rem;
+  background-color: #f5f5f5;
+  color: #333;
+  max-width: 75rem;
+  margin: 0 auto;
+}
+
+/* Class Selector */
+.section {
+  margin: 1.875rem 0;
+  padding: 1.5625rem;
+  border-radius: 0.5rem;
+  background-color: white;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease;
+}
+
+.section:hover {
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
+}
+
+/* ID Selector */
+#header {
+  background: linear-gradient(135deg, #2c3e50, #3498db);
+  color: white;
+  padding: 2.5rem 1.25rem;
+  text-align: center;
+  border-radius: 0.5rem;
+  margin-bottom: 2.5rem;
+}
+
+/* Headings */
+h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.625rem;
+  text-shadow: 0.125rem 0.125rem 0.25rem rgba(0, 0, 0, 0.2);
+}
+
+h2 {
+  color: #2c3e50;
+  margin-bottom: 0.9375rem;
+  font-size: 1.8em;
+}
+
+/* Code blocks */
+code {
+  display: block;
+  background-color: #f8f9fa;
+  padding: 0.9375rem;
+  border-radius: 0.375rem;
+  border-left: 0.25rem solid #3498db;
+  margin: 0.9375rem 0;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.9em;
+}
+
+/* Links and buttons */
+.back-btn {
+  position: fixed;
+  top: 1.25rem;
+  left: 1.25rem;
+  padding: 0.75rem 1.5rem;
+  background-color: #2c3e50;
+  color: white;
+  text-decoration: none;
+  border-radius: 1.5625rem;
+  font-weight: 500;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.2);
+  transition: all 0.3s ease;
+}
+
+.back-btn:hover {
+  background-color: #3498db;
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2);
+}
+
+/* Paragraphs */
+p {
+  color: #555;
+  margin-bottom: 0.9375rem;
+  font-size: 1.1em;
+}
+.intro {
+  margin-bottom: 0.9375rem;
+  font-size: 1.1em;
+  color: #f4f4f4f4;
+}
+
+/* Input fields */
+input[type="text"] {
+  padding: 0.625rem;
+  border: 0.125rem solid #ddd;
+  border-radius: 0.25rem;
+  width: 100%;
+  max-width: 18.75rem;
+  transition: border-color 0.3s ease;
+}
+
+input[type="text"]:focus {
+  border-color: #3498db;
+  outline: none;
+}
+
+/* Special elements */
+.child {
+  padding: 0.9375rem;
+  background-color: #e8f4f8;
+  border-radius: 0.375rem;
+}
+
+.nested-child {
+  padding: 0.9375rem;
+  background-color: #f8e8f8;
+  border-radius: 0.375rem;
+  margin-top: 0.625rem;
+}
+
+/* Highlighted elements */
+p.special.highlighted {
+  background-color: #fff3cd;
+  padding: 0.9375rem;
+  border-radius: 0.375rem;
+  border-left: 0.25rem solid #ffc107;
+}
+
+/* Demo links */
+a:not(.back-btn) {
+  color: #3498db;
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+a:not(.back-btn):hover {
+  color: #2c3e50;
+  text-decoration: underline;
+}
+
+/* Theory section styles */
+.theory {
+  background-color: #f0f7ff;
+  padding: 0.9375rem;
+  padding-left: 2rem;
+  margin-top: 0.625rem;
+  border-radius: 0.375rem;
+  border-left: 0.25rem solid #2196f3;
+}
+
+.specificity {
+  font-weight: bold;
+  color: #e91e63;
+}
+
+.combinator-demo .parent {
+  border: 0.125rem solid #333;
+  padding: 0.625rem;
+  margin: 0.625rem 0;
+}
+.combinator-demo .child {
+  background: #f0f0f0;
+  padding: 0.3125rem;
+  margin: 0.3125rem;
+}
+.combinator-demo .sibling {
+  border: 0.0625rem dashed #666;
+  padding: 0.3125rem;
+  margin: 0.3125rem;
+}
+.combinator-demo .highlight {
+  background: #ffeb3b;
+}

--- a/HTML/selectors.html
+++ b/HTML/selectors.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Learn CSS Selectors">
+    <meta name="author" content="Suraj Ingole">
+    <meta name="keywords" content="css, css tutorial css selectors, css learning">
+    <meta name="robots" content="index, follow">
+    <link rel="stylesheet" href="../CSS/selectors.css">
+    <link rel="shortcut icon" href="../images/css_favicon.png" type="image/x-icon">
+    <title>CSS Selectors Guide</title>
+</head>
+<body>
+    <a href="../index.html" class="back-btn">Back</a>
+    
+    <div id="header">
+        <h1>CSS Selectors Guide</h1>
+        <p class="intro">Understanding CSS Selectors and Their Specificity</p>
+    </div>
+
+    <div class="section">
+        <h2>Universal Selector (*)</h2>
+        <p>Selects all elements on the page. Used for global styles.</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-0-0</span></p>
+            <p>The universal selector is often used for CSS resets and applying base styles. It has the lowest specificity and will be overridden by any other selector. Use with caution as it can impact performance when overused.</p>
+        </div>
+        <code>* { margin: 0; padding: 0; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Type Selector</h2>
+        <p>Selects all elements of specified type.</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-0-1</span></p>
+            <p>Element selectors target HTML elements directly by their tag name. They have low specificity but are useful for setting default styles for particular elements across your website.</p>
+        </div>
+        <code>p { color: blue; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Class Selector (.)</h2>
+        <p class="special">Selects elements with specific class.</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-1-0</span></p>
+            <p>Class selectors are reusable and can be applied to multiple elements. They're the most flexible way to style elements and are fundamental to maintaining clean, modular CSS. Multiple classes can be applied to a single element.</p>
+        </div>
+        <code>.special { color: green; }</code>
+    </div>
+
+    <div class="section">
+        <h2>ID Selector (#)</h2>
+        <p>Selects element with specific ID. Should be unique.</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 1-0-0</span></p>
+            <p>ID selectors have the highest specificity among simple selectors. They should be used sparingly as they can make styles difficult to override and maintain. Best reserved for unique elements that appear once on a page.</p>
+        </div>
+        <code>#header { background: black; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Pseudo-Class Selector (:)</h2>
+        <a href="#">Hover over me!</a>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-1-0</span></p>
+            <p>Pseudo-classes target special states of elements like :hover, :focus, :first-child, etc. They're crucial for creating interactive and dynamic interfaces without JavaScript.</p>
+        </div>
+        <code>a:hover { color: red; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Pseudo-Element Selector (::)</h2>
+        <p>Notice the first letter styling.</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-0-1</span></p>
+            <p>Pseudo-elements create artificial elements in the document tree, allowing you to style specific parts of an element like ::first-letter, ::before, ::after. They're powerful for adding decorative content.</p>
+        </div>
+        <code>p::first-letter { font-size: 2em; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Combinators</h2>
+        <div class="theory">
+            <p>CSS combinators define relationships between selectors:</p>
+            <ul>
+                <li>
+                    <strong>Descendant (space):</strong> Matches nested elements at any depth
+                    <div class="combinator-demo">
+                        <div class="parent">Parent
+                            <div class="child">Child
+                                <span class="highlight">Descendant</span>
+                            </div>
+                        </div>
+                        <code>div span { color: blue; }</code>
+                    </div>
+                </li>
+                <li>
+                    <strong>Child (>):</strong> Matches direct children only
+                    <div class="combinator-demo">
+                        <div class="parent">Parent
+                            <div class="child highlight">Direct Child</div>
+                            <div class="child">Child
+                                <div>Not Selected</div>
+                            </div>
+                        </div>
+                        <code>div > div { border-color: red; }</code>
+                    </div>
+                </li>
+                <li>
+                    <strong>Adjacent Sibling (+):</strong> Matches the next sibling
+                    <div class="combinator-demo">
+                        <div class="sibling">First</div>
+                        <div class="sibling highlight">Adjacent to First</div>
+                        <div class="sibling">Not Selected</div>
+                        <code>div + div { background-color: #ffeb3b; }</code>
+                    </div>
+                </li>
+                <li>
+                    <strong>General Sibling (~):</strong> Matches all following siblings
+                    <div class="combinator-demo">
+                        <div class="sibling">First</div>
+                        <div class="sibling highlight">Selected Sibling</div>
+                        <div class="sibling highlight">Also Selected</div>
+                        <code>div ~ div { background-color: #ffeb3b; }</code>
+                    </div>
+                </li>
+            </ul>
+            <div class="theory-details">
+                <p><span class="specificity">Specificity: Varies based on selectors used</span></p>
+                <p>Combinators are powerful tools for creating specific styling rules based on element relationships:</p>
+                <ul>
+                    <li>Descendant combinators (space) are the most flexible but can affect performance if too broad</li>
+                    <li>Child combinators (>) provide better performance and more precise targeting</li>
+                    <li>Sibling combinators (+, ~) are useful for styling sequential elements without adding classes</li>
+                </ul>
+                <p>Best Practices:</p>
+                <ul>
+                    <li>Use child combinators over descendant when possible for better performance</li>
+                    <li>Avoid deeply nested descendant selectors</li>
+                    <li>Consider using classes for complex selections instead of multiple combinators</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <!-- <h2>Attribute Selector</h2>
+        <input type="text" placeholder="Type here...">
+        <div class="theory">
+            <p><span class="specificity">Specificity: 0-1-0</span></p>
+            <p>Attribute selectors target elements based on their attributes or attribute values. They support pattern matching with prefixes (^=), suffixes ($=), contains (*=), and more.</p>
+        </div> -->
+          <h2>Attribute Selector</h2>
+
+  <!-- Example Input Element -->
+  <input type="text" placeholder="Type here...">
+
+  <!-- Theory Section -->
+  <div class="theory">
+    <p><span class="specificity">Specificity: 0-1-0</span></p>
+    <p>
+      Attribute selectors target elements based on their attributes or attribute values.
+      They support pattern matching using:
+    </p>
+    <ul>
+      <li><code>[attr]</code> — Elements with the attribute</li>
+      <li><code>[attr="value"]</code> — Attribute equals specific value</li>
+      <li><code>[attr^="value"]</code> — Attribute starts with value</li>
+      <li><code>[attr$="value"]</code> — Attribute ends with value</li>
+      <li><code>[attr*="value"]</code> — Attribute contains value</li>
+    </ul>
+  </div>
+        <code>input[type="text"] { padding: 5px; }</code>
+    </div>
+
+    <div class="section">
+        <h2>Compound Selector</h2>
+        <p class="special highlighted">Combined multiple classes</p>
+        <div class="theory">
+            <p><span class="specificity">Specificity: Cumulative</span></p>
+            <p>Compound selectors combine multiple simple selectors without a combinator. They're useful for targeting specific elements that meet multiple criteria. The specificity is the sum of all included selectors.</p>
+        </div>
+        <code>p.special.highlighted { background: yellow; }</code>
+    </div>
+
+    <div class="nested-parent section">
+        <h2>CSS Nesting</h2>
+        <div class="nested-child">Nested element styling</div>
+        <div class="theory">
+            <p>Modern CSS supports nesting, similar to preprocessors like Sass. This helps maintain cleaner, more organized stylesheets by grouping related styles together.</p>
+        </div>
+        <code>.nested-parent { .nested-child { color: purple; } }</code>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <ul class="file-list">
         <li><a href="HTML/what-is-css.html">What is CSS</a></li>
         <li><a href="HTML/stylesheet-type.html">CSS Stylesheet Types</a></li>
+        <li><a href="HTML/selectors.html">CSS Selectors</a></li>
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add new HTML page demonstrating various CSS selectors with interactive examples and detailed theory sections explaining specificity and usage. Includes companion CSS file with all necessary styles for the demonstration.