### PR TITLE
feat(lists): add css lists documentation and demo page

### DIFF
--- a/CSS/list.css
+++ b/CSS/list.css
@@ -1,0 +1,166 @@
+/* list.css: Styles for the CSS lists demo page */
+
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+
+.container {
+  max-width: 950px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+
+h1 {
+  text-align: center;
+  color: #3498db;
+  margin-bottom: 16px;
+}
+
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+
+.code-block {
+  background: #181a20;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.code-block code {
+  color: #ffd200;
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  font-size: 1rem;
+}
+
+.demo-section {
+  background: #f7f9fb;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.08);
+  padding: 12px 10px 10px 10px;
+  min-width: 120px;
+  min-height: 120px;
+  transition: box-shadow 0.3s, transform 0.2s;
+  margin-bottom: 8px;
+}
+.demo-card:hover, .demo-card:focus-within {
+  box-shadow: 0 8px 32px 0 #3498db44;
+  transform: translateY(-4px) scale(1.04);
+}
+.demo-list {
+  margin: 10px 0 0 0;
+  padding-left: 28px;
+  font-size: 1.08rem;
+  background: #f3f7fa;
+  border-radius: 7px;
+  box-shadow: 0 1px 4px 0 #3498db22;
+  min-width: 120px;
+  max-width: 260px;
+  transition: box-shadow 0.2s;
+}
+.demo-list li {
+  margin-bottom: 4px;
+  padding: 3px 0 3px 2px;
+  line-height: 1.6;
+}
+.demo-list.image-list li, .demo-list.shorthand-list li {
+  min-height: 32px;
+  background: #fffbe6;
+  border-radius: 4px;
+  padding-left: 2px;
+}
+.demo-list.image-list {
+  background: #fffbe6;
+  border: 1px solid #ffd200;
+}
+.demo-list.shorthand-list {
+  background: #eaf7ff;
+  border: 1px solid #3498db;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 22px;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.12);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+ul.disc-list {
+  list-style-type: disc;
+}
+ul.square-list {
+  list-style-type: square;
+}
+ul.circle-list {
+  list-style-type: circle;
+}
+ol.lower-alpha-list {
+  list-style-type: lower-alpha;
+}
+ul.inside-list {
+  list-style-position: inside;
+}
+ul.outside-list {
+  list-style-position: outside;
+}
+ul.image-list {
+  list-style-image: url('https://img.icons8.com/color/32/super-mario.png');
+}
+ul.shorthand-list {
+  list-style: square inside url('https://img.icons8.com/color/32/super-mario.png');
+}
+.back-btn:hover, .back-btn:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #3498db 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+@media (max-width: 700px) {
+  .container {
+    padding: 10px 2vw;
+  }
+  .demo-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .demo-card {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/HTML/list.html
+++ b/HTML/list.html
@@ -1,0 +1,131 @@
+<!-- list : list-style-type, list-style-position, list-style-image, list-style shorthand property -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="CSS Lists: list-style-type, list-style-position, list-style-image, list-style - Theory, Examples, and Demos">
+  <title>CSS Lists</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/list.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS List Properties</h1>
+    <section class="theory-section">
+      <h2>Theory & Explanation</h2>
+      <p>CSS provides several properties to control the appearance of HTML lists. You can change the bullet or numbering style, use custom images, and control the position of the marker. These properties work for both ordered (<code>&lt;ol&gt;</code>) and unordered (<code>&lt;ul&gt;</code>) lists, as well as <code>&lt;li&gt;</code> elements.</p>
+      <p><strong>How List Markers Work:</strong> The marker (bullet, number, or image) is rendered by the browser before each <code>&lt;li&gt;</code> item. The <code>list-style-type</code> property lets you choose from built-in marker types (disc, square, decimal, lower-alpha, etc.), while <code>list-style-image</code> allows you to use a custom image. <code>list-style-position</code> controls whether the marker is inside the content box (flows with text) or outside (default, aligns with the list edge).</p>
+      <p><strong>Accessibility & Best Practices:</strong> Always ensure your list markers are visible and meaningful. Custom images should be clear and high-contrast. For navigation menus, consider using ARIA roles and semantic HTML. Avoid removing list markers for important content, as they help users scan and understand structure.</p>
+      <p><strong>Advanced Tips:</strong> You can combine list properties for creative effects, such as using emojis or SVGs as markers, or styling <code>::marker</code> in modern browsers for even more control. The <code>list-style</code> shorthand lets you set all three properties at once.</p>
+      <ul>
+        <li><strong>list-style-type</strong>: Sets the marker type (disc, circle, square, decimal, lower-alpha, etc.).</li>
+        <li><strong>list-style-position</strong>: Sets whether the marker is inside or outside the list item's content box.</li>
+        <li><strong>list-style-image</strong>: Uses a custom image as the marker.</li>
+        <li><strong>list-style</strong>: Shorthand for all three properties.</li>
+      </ul>
+      <p>Lists are essential for structuring content, navigation menus, and more. Customizing list styles improves readability and visual appeal.</p>
+    </section>
+
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block">
+        <pre><code>ul.disc-list {
+  list-style-type: disc;
+}
+ul.square-list {
+  list-style-type: square;
+}
+ul.circle-list {
+  list-style-type: circle;
+}
+ol.lower-alpha-list {
+  list-style-type: lower-alpha;
+}
+ul.inside-list {
+  list-style-position: inside;
+}
+ul.outside-list {
+  list-style-position: outside;
+}
+ul.image-list {
+  list-style-image: url('https://img.icons8.com/color/32/super-mario.png');
+}
+ul.shorthand-list {
+  list-style: square inside url('https://img.icons8.com/color/32/super-mario.png');
+}
+</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Live Demos</h2>
+      <div class="demo-row">
+        <div class="demo-card">
+          <span>disc (default)</span>
+          <ul class="demo-list disc-list">
+            <li>HTML</li>
+            <li>CSS</li>
+            <li>JavaScript</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>square</span>
+          <ul class="demo-list square-list">
+            <li>Apple</li>
+            <li>Banana</li>
+            <li>Cherry</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>circle</span>
+          <ul class="demo-list circle-list">
+            <li>Dog</li>
+            <li>Cat</li>
+            <li>Bird</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>lower-alpha</span>
+          <ol class="demo-list lower-alpha-list">
+            <li>First</li>
+            <li>Second</li>
+            <li>Third</li>
+          </ol>
+        </div>
+        <div class="demo-card">
+          <span>inside</span>
+          <ul class="demo-list inside-list">
+            <li>This marker is inside</li>
+            <li>Second item</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>outside</span>
+          <ul class="demo-list outside-list">
+            <li>This marker is outside</li>
+            <li>Second item</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>image</span>
+          <ul class="demo-list image-list">
+            <li>Super Mario marker</li>
+            <li>Another item</li>
+          </ul>
+        </div>
+        <div class="demo-card">
+          <span>shorthand</span>
+          <ul class="demo-list shorthand-list">
+            <li>All in one</li>
+            <li>Shorthand style</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -579,6 +579,58 @@ filter: grayscale(100%) blur(4px) brightness(1.2) contrast(120%) saturate(150%) 
 
 ---
 
+## 15. CSS Lists
+
+CSS provides several properties to control the appearance of HTML lists, including the marker type, position, and even custom images. These properties help you create visually appealing navigation menus, checklists, and more.
+
+### List Properties
+- **list-style-type**: Sets the marker type (e.g., disc, circle, square, decimal, lower-alpha, upper-roman, etc.).
+- **list-style-position**: Sets whether the marker is inside or outside the list item's content box.
+- **list-style-image**: Uses a custom image as the marker.
+- **list-style**: Shorthand for all three properties.
+
+### Syntax
+```css
+ul {
+  list-style-type: disc;
+  list-style-position: outside;
+  list-style-image: none;
+}
+
+ol {
+  list-style-type: decimal;
+}
+
+ul.custom {
+  list-style: square inside url('star.png');
+}
+```
+
+### Examples
+```css
+ul.disc-list { list-style-type: disc; }
+ul.square-list { list-style-type: square; }
+ul.circle-list { list-style-type: circle; }
+ol.lower-alpha-list { list-style-type: lower-alpha; }
+ul.inside-list { list-style-position: inside; }
+ul.outside-list { list-style-position: outside; }
+ul.image-list { list-style-image: url('custom-marker.png'); }
+ul.shorthand-list { list-style: square inside url('custom-marker.png'); }
+```
+
+### Best Practices
+- Use `list-style-type` for simple marker changes.
+- Use `list-style-image` for branding or custom icons, but provide a fallback.
+- Use `list-style-position: inside` for checklists or when you want the marker to be part of the content flow.
+- Use the `list-style` shorthand for concise code.
+- Test list styles for accessibility and readability.
+
+### Browser Compatibility
+- All list properties are supported in all modern browsers (Chrome, Firefox, Edge, Safari, Opera).
+- Custom images may not display if the URL is incorrect or the image is missing.
+
+---
+
 ## ✅ Summary Tips
 - Use an **external CSS** file for scalability.
 - Organize your CSS with **clear comments** and **consistent naming conventions**.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
         <li><a href="HTML/box-shadow.html">CSS Box Shadow</a></li>
         <li><a href="HTML/drop-shadow.html">CSS Drop Shadow</a></li>
         <li><a href="HTML/filters.html">CSS Filters</a></li>
+        <li><a href="HTML/list.html">CSS Lists</a></li>
+
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add new HTML/CSS demo page showcasing list styling properties including:
- list-style-type with various marker types
- list-style-position for inside/outside markers
- list-style-image for custom markers
- list-style shorthand property

Includes comprehensive documentation in Summary.md covering syntax, examples, best practices and browser compatibility.