### PR TITLE
feat: add CSS display and anchor state demo pages

### DIFF
--- a/CSS/anchor-state.css
+++ b/CSS/anchor-state.css
@@ -75,7 +75,7 @@ h1 {
   transition: box-shadow 0.3s, transform 0.2s;
   margin-bottom: 8px;
 }
-.demo-card:hover, .demo-card:focus-within {
+.demo-card:hover, .demo-card:focus {
   box-shadow: 0 8px 32px 0 #3498db44;
   transform: translateY(-4px) scale(1.04);
 }
@@ -155,6 +155,12 @@ h1 {
 .button-link:active {
   background: #23272e;
   color: #ffd200;
+}
+.demo-notes {
+  margin-top: 18px;
+  color: #888;
+  font-size: 0.98rem;
+  text-align: center;
 }
 @media (max-width: 700px) {
   .container {

--- a/CSS/anchor-state.css
+++ b/CSS/anchor-state.css
@@ -1,0 +1,171 @@
+/* anchor-state.css: Styles for the CSS anchor state demo page */
+
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+
+h1 {
+  text-align: center;
+  color: #3498db;
+  margin-bottom: 16px;
+}
+
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+
+.code-block {
+  background: #181a20;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.code-block code {
+  color: #ffd200;
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  font-size: 1rem;
+}
+
+.demo-section {
+  background: #f7f9fb;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.08);
+  padding: 12px 10px 10px 10px;
+  min-width: 180px;
+  min-height: 120px;
+  transition: box-shadow 0.3s, transform 0.2s;
+  margin-bottom: 8px;
+}
+.demo-card:hover, .demo-card:focus-within {
+  box-shadow: 0 8px 32px 0 #3498db44;
+  transform: translateY(-4px) scale(1.04);
+}
+.demo-label {
+  font-weight: 600;
+  color: #8e44ad;
+  margin-bottom: 8px;
+}
+.demo-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  margin-top: 10px;
+}
+.demo-links a {
+  font-size: 1.1rem;
+  padding: 6px 14px;
+  border-radius: 5px;
+  text-decoration: none;
+  color: #3498db;
+  background: #eaf7ff;
+  transition: color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.demo-links a:link {
+  color: #3498db;
+  background: #eaf7ff;
+}
+.demo-links a:visited {
+  color: #8e44ad;
+  background: #f7eaff;
+}
+.demo-links a:hover, .demo-links a:focus {
+  color: #fff;
+  background: #3498db;
+  text-decoration: underline;
+  box-shadow: 0 2px 8px 0 #3498db33;
+}
+.demo-links a:active {
+  color: #ffd200;
+  background: #23272e;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 22px;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.12);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+.back-btn:hover, .back-btn:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #3498db 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+.button-link:link, .button-link:visited {
+  display: inline-block;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  padding: 8px 20px;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+.button-link:hover, .button-link:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #3498db 100%);
+  color: #ffd200;
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  text-decoration: underline;
+}
+.button-link:active {
+  background: #23272e;
+  color: #ffd200;
+}
+@media (max-width: 700px) {
+  .container {
+    padding: 10px 2vw;
+  }
+  .demo-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .demo-card {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/CSS/display.css
+++ b/CSS/display.css
@@ -143,9 +143,9 @@ h1 {
   min-height: 32px;
 }
 .demo-desc {
+  margin-top: 18px;
   color: #888;
   font-size: 0.98rem;
-  margin-top: 8px;
   text-align: center;
 }
 .demo-flex {

--- a/CSS/display.css
+++ b/CSS/display.css
@@ -1,0 +1,218 @@
+/* display.css: Styles for the CSS display property demo page */
+
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+
+h1 {
+  text-align: center;
+  color: #3498db;
+  margin-bottom: 16px;
+}
+
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+
+.code-block {
+  background: #181a20;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.code-block code {
+  color: #ffd200;
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  font-size: 1rem;
+}
+
+.demo-section {
+  background: #f7f9fb;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.08);
+  padding: 12px 10px 10px 10px;
+  min-width: 180px;
+  min-height: 120px;
+  transition: box-shadow 0.3s, transform 0.2s;
+  margin-bottom: 8px;
+}
+.demo-card:hover, .demo-card:focus-within {
+  box-shadow: 0 8px 32px 0 #3498db44;
+  transform: translateY(-4px) scale(1.04);
+}
+.demo-label {
+  font-weight: 600;
+  color: #8e44ad;
+  margin-bottom: 8px;
+}
+.demo-box {
+  background: #eaf7ff;
+  border: 2px dashed #3498db;
+  border-radius: 6px;
+  padding: 10px 16px;
+  margin: 4px 0;
+  font-size: 1.08rem;
+  min-width: 60px;
+  min-height: 32px;
+  display: block;
+  text-align: center;
+  transition: background 0.2s, border 0.2s;
+}
+.inline-demo .demo-box {
+  display: inline;
+  background: #fffbe6;
+  border: 2px solid #ffd200;
+  min-width: 0;
+  min-height: 0;
+  padding: 0 8px;
+}
+.inline-block-demo .demo-box {
+  display: inline-block;
+  background: #e6ffe6;
+  border: 2px solid #27ae60;
+  min-width: 60px;
+  min-height: 32px;
+}
+.none-demo .demo-box {
+  display: none;
+}
+.demo-mixed {
+  margin: 10px 0 0 0;
+}
+.demo-mixed .demo-box {
+  margin: 0 6px 0 0;
+}
+.mixed-block {
+  display: block;
+  background: #eaf7ff;
+  border: 2px dashed #3498db;
+  margin-bottom: 6px;
+}
+.mixed-inline {
+  display: inline;
+  background: #fffbe6;
+  border: 2px solid #ffd200;
+  min-width: 0;
+  min-height: 0;
+  padding: 0 8px;
+}
+.mixed-inline-block {
+  display: inline-block;
+  background: #e6ffe6;
+  border: 2px solid #27ae60;
+  min-width: 60px;
+  min-height: 32px;
+}
+.demo-desc {
+  color: #888;
+  font-size: 0.98rem;
+  margin-top: 8px;
+  text-align: center;
+}
+.demo-flex {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+  justify-content: center;
+}
+.flex-item {
+  background: #f0e6ff;
+  border: 2px solid #8e44ad;
+  color: #8e44ad;
+  min-width: 40px;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  border-radius: 8px;
+  font-size: 1.1rem;
+}
+.toggle-btn {
+  margin-top: 10px;
+  padding: 7px 18px;
+  background: linear-gradient(90deg, #ffd200 60%, #8e44ad 100%);
+  color: #23272e;
+  border: none;
+  border-radius: 5px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 2px 8px 0 #ffd20033;
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 22px;
+  background: linear-gradient(90deg, #8e44ad 60%, #3498db 100%);
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.12);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+.back-btn:hover, .back-btn:focus {
+  background: linear-gradient(90deg, #3498db 0%, #8e44ad 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+.toggle-btn:hover, .toggle-btn:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #ffd200 100%);
+  color: #fff;
+  transform: translateY(-2px) scale(1.03);
+}
+@media (max-width: 700px) {
+  .container {
+    padding: 10px 2vw;
+  }
+  .demo-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .demo-card {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/HTML/anchor-state.html
+++ b/HTML/anchor-state.html
@@ -110,7 +110,7 @@ a:active {
           </nav>
         </div>
       </div>
-      <p style="margin-top:18px; color:#888; font-size:0.98rem;">Try clicking, hovering, tabbing, and visiting the links above to see the different anchor states in action. Button-style links and navigation links demonstrate advanced styling and accessibility.</p>
+      <p class="demo-notes">Try clicking, hovering, tabbing, and visiting the links above to see the different anchor states in action. Button-style links and navigation links demonstrate advanced styling and accessibility.</p>
     </section>
     <a href="../index.html" class="back-btn">&larr; Back to Home</a>
   </div>

--- a/HTML/anchor-state.html
+++ b/HTML/anchor-state.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="CSS Anchor States: :link, :hover, :visited, :active - Theory, Examples, and Demos">
+  <title>CSS Anchor States</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/anchor-state.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Anchor States</h1>
+    <section class="theory-section">
+      <h2>Theory & Explanation</h2>
+      <p>Anchor elements (<code>&lt;a&gt;</code>) are used to create hyperlinks in HTML. CSS provides pseudo-classes to style links based on their state, improving usability and accessibility. The five main anchor states are:</p>
+      <ul>
+        <li><strong>:link</strong> — Unvisited links (default state). Applies to all <code>&lt;a&gt;</code> elements with an <code>href</code> that haven't been visited.</li>
+        <li><strong>:visited</strong> — Links the user has already visited. Browsers limit which properties can be styled for privacy.</li>
+        <li><strong>:hover</strong> — When the mouse pointer is over the link. Use for visual feedback.</li>
+        <li><strong>:active</strong> — When the link is being clicked (between mousedown and mouseup).</li>
+        <li><strong>:focus</strong> — When the link is focused (e.g., via keyboard navigation or mouse click). Essential for accessibility.</li>
+      </ul>
+      <p><strong>Order matters:</strong> Always use the LVHAF order in your CSS: <code>:link</code>, <code>:visited</code>, <code>:hover</code>, <code>:active</code>, <code>:focus</code>. This ensures all states are styled as expected.</p>
+      <h3>How Anchor States Work</h3>
+      <ul>
+        <li><strong>Unvisited links</strong> are styled with <code>:link</code> until the user clicks them.</li>
+        <li><strong>Visited links</strong> change to <code>:visited</code> after the user visits the URL (if allowed by browser privacy).</li>
+        <li><strong>Hover</strong> and <strong>focus</strong> provide visual feedback for mouse and keyboard users.</li>
+        <li><strong>Active</strong> is a brief state while the link is being clicked.</li>
+        <li>Browsers restrict <code>:visited</code> styling to color, background-color, border-color, and outline-color for privacy.</li>
+      </ul>
+      <h3>Accessibility & Best Practices</h3>
+      <ul>
+        <li>Always provide a visible <code>:focus</code> style for keyboard users.</li>
+        <li>Use <code>:hover</code> and <code>:focus</code> together for consistent experience.</li>
+        <li>Style <code>:visited</code> to help users distinguish visited links, but avoid using sensitive color cues.</li>
+        <li>Don't remove underline unless you provide another clear indicator (e.g., color, background, or border).</li>
+        <li>Use semantic <code>&lt;a&gt;</code> elements for navigation and actions that change the page or context.</li>
+      </ul>
+    </section>
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block">
+        <pre><code>/* Basic anchor states */
+a:link {
+  color: #3498db;
+}
+a:visited {
+  color: #8e44ad;
+}
+a:hover, a:focus {
+  color: #fff;
+  background: #3498db;
+  text-decoration: underline;
+}
+a:active {
+  color: #ffd200;
+}
+
+/* Custom button-style link */
+.button-link:link, .button-link:visited {
+  display: inline-block;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  padding: 8px 20px;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+.button-link:hover, .button-link:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #3498db 100%);
+  color: #ffd200;
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  text-decoration: underline;
+}
+.button-link:active {
+  background: #23272e;
+  color: #ffd200;
+}
+</code></pre>
+      </div>
+    </section>
+    <section class="demo-section">
+      <h2>Live Demos</h2>
+      <div class="demo-row">
+        <div class="demo-card">
+          <span class="demo-label">Anchor States Demo</span>
+          <div class="demo-links">
+            <a href="https://www.example.com" target="_blank" rel="noopener">Unvisited Link</a>
+            <a href="https://www.wikipedia.org" target="_blank" rel="noopener">Visit Me (Wikipedia)</a>
+            <a href="#" tabindex="0">Focusable Link</a>
+            <a href="https://www.example.com#anchor" target="_blank" rel="noopener">Active/Visited Demo</a>
+          </div>
+        </div>
+        <div class="demo-card">
+          <span class="demo-label">Button-Style Link</span>
+          <a href="https://www.css-tricks.com" class="button-link" target="_blank" rel="noopener">CSS-Tricks (Button Link)</a>
+        </div>
+        <div class="demo-card">
+          <span class="demo-label">Navigation Example</span>
+          <nav class="demo-links">
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:link" target="_blank" rel="noopener">MDN :link</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:visited" target="_blank" rel="noopener">MDN :visited</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:hover" target="_blank" rel="noopener">MDN :hover</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:active" target="_blank" rel="noopener">MDN :active</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus" target="_blank" rel="noopener">MDN :focus</a>
+          </nav>
+        </div>
+      </div>
+      <p style="margin-top:18px; color:#888; font-size:0.98rem;">Try clicking, hovering, tabbing, and visiting the links above to see the different anchor states in action. Button-style links and navigation links demonstrate advanced styling and accessibility.</p>
+    </section>
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+</body>
+</html>

--- a/HTML/display.html
+++ b/HTML/display.html
@@ -103,7 +103,7 @@
           <p class="demo-desc">Block starts on a new line, inline flows, inline-block is inline but sized.</p>
         </div>
       </div>
-      <p style="margin-top:18px; color:#888; font-size:0.98rem;">Try toggling the display type of each demo using the buttons, or inspect the elements to see how <code>display</code> changes their layout and visibility.</p>
+      <p class="demo-desc">Try toggling the display type of each demo using the buttons, or inspect the elements to see how <code>display</code> changes their layout and visibility.</p>
     </section>
 
     <a href="../index.html" class="back-btn">&larr; Back to Home</a>
@@ -116,27 +116,28 @@ document.querySelectorAll('.toggle-btn').forEach(function(btn) {
     const target = btn.getAttribute('data-target');
     const boxes = card.querySelectorAll('.demo-box');
     boxes.forEach(function(box) {
-      // Toggle display property based on the demo type
+      // Use computed style for accurate current display
+      const computedDisplay = window.getComputedStyle(box).display;
       if (target === 'block') {
-        if (box.style.display === 'inline') {
+        if (computedDisplay === 'inline') {
           box.style.display = '';
         } else {
           box.style.display = 'inline';
         }
       } else if (target === 'inline') {
-        if (box.style.display === 'block' || box.style.display === '') {
+        if (computedDisplay === 'block') {
           box.style.display = 'inline';
         } else {
           box.style.display = 'block';
         }
       } else if (target === 'inline-block') {
-        if (box.style.display === 'block' || box.style.display === '') {
+        if (computedDisplay === 'block') {
           box.style.display = 'inline-block';
         } else {
           box.style.display = 'block';
         }
       } else if (target === 'none') {
-        if (box.style.display === 'none') {
+        if (computedDisplay === 'none') {
           box.style.display = 'block';
         } else {
           box.style.display = 'none';

--- a/HTML/display.html
+++ b/HTML/display.html
@@ -1,0 +1,150 @@
+<!-- display: block-level element,inline-level element,inline-block element, none -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="CSS Display Property: block, inline, inline-block, none - Theory, Examples, and Demos">
+  <title>CSS Display Property</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/display.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>display</code> Property</h1>
+    <section class="theory-section">
+      <h2>Theory & Explanation</h2>
+      <p>The <strong>display</strong> property in CSS is the foundation of layout and rendering. It controls how elements are visually formatted, how they participate in the document flow, and how they interact with other elements. Mastery of <code>display</code> is essential for building any web layout, from simple pages to complex applications.</p>
+      <ul>
+        <li><strong>block</strong>: Starts on a new line, stretches to fill the container's width, and can have width, height, margin, and padding. Block elements stack vertically. <br><em>Examples:</em> <code>&lt;div&gt;</code>, <code>&lt;h1&gt;</code>, <code>&lt;p&gt;</code>, <code>&lt;ul&gt;</code></li>
+        <li><strong>inline</strong>: Flows within the current line, only as wide as its content. Width/height/margin-top/margin-bottom are ignored. <br><em>Examples:</em> <code>&lt;span&gt;</code>, <code>&lt;a&gt;</code>, <code>&lt;strong&gt;</code></li>
+        <li><strong>inline-block</strong>: Behaves like <code>inline</code> (flows in line), but you can set width, height, margin, and padding. Useful for buttons, badges, and custom controls.</li>
+        <li><strong>none</strong>: The element is completely removed from the layout and accessibility tree. It is as if it does not exist in the DOM.</li>
+      </ul>
+      <p><strong>Other values:</strong> <code>flex</code> (for flexible box layouts), <code>grid</code> (for grid layouts), <code>table</code> (for table-like layouts), and more. These advanced values enable powerful, responsive designs.</p>
+      <h3>How <code>display</code> Affects Layout</h3>
+      <ul>
+        <li><strong>Block formatting context:</strong> Block elements create a new line and stack vertically. They can contain other block or inline elements.</li>
+        <li><strong>Inline formatting context:</strong> Inline elements flow horizontally, wrapping as needed. They cannot have width/height set.</li>
+        <li><strong>Inline-block:</strong> Inline placement, but block-like sizing and box model.</li>
+        <li><strong>None:</strong> Element is not rendered and does not take up space.</li>
+      </ul>
+      <h3>Accessibility & Best Practices</h3>
+      <ul>
+        <li>Use semantic HTML elements for structure, then use <code>display</code> to adjust layout as needed.</li>
+        <li>Be careful with <code>display: none</code>—it hides content from all users, including screen readers.</li>
+        <li>For interactive UI, prefer <code>inline-block</code> or <code>flex</code> for custom controls and layouts.</li>
+        <li>Test your layout with different content lengths and screen sizes.</li>
+      </ul>
+    </section>
+
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block">
+        <pre><code>/* Block-level */
+.block-demo .demo-box {
+  display: block;
+}
+
+/* Inline-level */
+.inline-demo .demo-box {
+  display: inline;
+}
+
+/* Inline-block */
+.inline-block-demo .demo-box {
+  display: inline-block;
+}
+
+/* None */
+.none-demo .demo-box {
+  display: none;
+}
+</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Live Demos & Interactive Examples</h2>
+      <div class="demo-row">
+        <div class="demo-card block-demo">
+          <span class="demo-label">block</span>
+          <div class="demo-box">Block 1</div>
+          <div class="demo-box">Block 2</div>
+          <button class="toggle-btn" data-target="block">Toggle Block/Inline</button>
+        </div>
+        <div class="demo-card inline-demo">
+          <span class="demo-label">inline</span>
+          <div class="demo-box">Inline 1</div>
+          <div class="demo-box">Inline 2</div>
+          <button class="toggle-btn" data-target="inline">Toggle Inline/Block</button>
+        </div>
+        <div class="demo-card inline-block-demo">
+          <span class="demo-label">inline-block</span>
+          <div class="demo-box">Inline-block 1</div>
+          <div class="demo-box">Inline-block 2</div>
+          <button class="toggle-btn" data-target="inline-block">Toggle Inline-block/Block</button>
+        </div>
+        <div class="demo-card none-demo">
+          <span class="demo-label">none</span>
+          <div class="demo-box">You can't see me!</div>
+          <button class="toggle-btn" data-target="none">Toggle None/Block</button>
+        </div>
+      </div>
+      <div class="demo-row">
+        <div class="demo-card">
+          <span class="demo-label">Mixed Example</span>
+          <div class="demo-mixed">
+            <span class="demo-box mixed-block">Block</span>
+            <span class="demo-box mixed-inline">Inline</span>
+            <span class="demo-box mixed-inline-block">Inline-block</span>
+          </div>
+          <p class="demo-desc">Block starts on a new line, inline flows, inline-block is inline but sized.</p>
+        </div>
+      </div>
+      <p style="margin-top:18px; color:#888; font-size:0.98rem;">Try toggling the display type of each demo using the buttons, or inspect the elements to see how <code>display</code> changes their layout and visibility.</p>
+    </section>
+
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+
+  <script>
+document.querySelectorAll('.toggle-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    const card = btn.closest('.demo-card');
+    const target = btn.getAttribute('data-target');
+    const boxes = card.querySelectorAll('.demo-box');
+    boxes.forEach(function(box) {
+      // Toggle display property based on the demo type
+      if (target === 'block') {
+        if (box.style.display === 'inline') {
+          box.style.display = '';
+        } else {
+          box.style.display = 'inline';
+        }
+      } else if (target === 'inline') {
+        if (box.style.display === 'block' || box.style.display === '') {
+          box.style.display = 'inline';
+        } else {
+          box.style.display = 'block';
+        }
+      } else if (target === 'inline-block') {
+        if (box.style.display === 'block' || box.style.display === '') {
+          box.style.display = 'inline-block';
+        } else {
+          box.style.display = 'block';
+        }
+      } else if (target === 'none') {
+        if (box.style.display === 'none') {
+          box.style.display = 'block';
+        } else {
+          box.style.display = 'none';
+        }
+      }
+    });
+  });
+});
+</script>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -631,6 +631,92 @@ ul.shorthand-list { list-style: square inside url('https://img.icons8.com/color/
 
 ---
 
+## 15. CSS Display Property
+
+The `display` property in CSS is fundamental for controlling how elements are rendered and participate in the document layout. It determines whether an element behaves as a block, inline, inline-block, or is removed from the flow entirely.
+
+### Common Display Values
+
+- **block**: The element starts on a new line and stretches to fill the container's width. Examples: `<div>`, `<h1>`, `<p>`.
+- **inline**: The element flows within the current line, only taking up as much width as its content. Examples: `<span>`, `<a>`, `<strong>`.
+- **inline-block**: Like `inline`, but allows width and height to be set. Elements sit inline but behave like blocks.
+- **none**: The element is not rendered at all (removed from layout and accessibility tree).
+
+Other values include `flex`, `grid`, `table`, etc., but the above are the most common for basic layout control.
+
+### Example:
+```css
+.block-demo .demo-box {
+  display: block;
+}
+.inline-demo .demo-box {
+  display: inline;
+}
+.inline-block-demo .demo-box {
+  display: inline-block;
+}
+.none-demo .demo-box {
+  display: none;
+}
+```
+
+### Usage & Best Practices
+
+- Use `display` to control layout and stacking of elements.
+- Prefer semantic HTML elements (e.g., use `<nav>`, `<main>`, `<section>` for structure).
+- Hiding elements with `display: none` removes them from both the visual flow and assistive technology.
+- `inline-block` is useful for horizontal alignment with block-like control.
+- Inspect the [display.html](./HTML/display.html) page for live, interactive demos and code.
+
+### Reference
+See the updated [display.html](./HTML/display.html) page for a live example of the CSS display property, theory, and interactive demos.
+
+---
+
+## 16. CSS Anchor States (Links)
+
+CSS anchors (links) are styled using pseudo-classes to reflect their different states: normal, visited, hover, active, and focus. Understanding and styling these states is essential for usability, accessibility, and visual feedback.
+
+### Anchor States
+
+- `a:link` — Unvisited link (default state)
+- `a:visited` — Link the user has already visited
+- `a:hover` — Link when the mouse is over it
+- `a:active` — Link when being clicked
+- `a:focus` — Link when focused (e.g., via keyboard navigation)
+
+### Example
+
+```css
+a:link {
+  color: #3498db;
+}
+a:visited {
+  color: #8e44ad;
+}
+a:hover, a:focus {
+  color: #fff;
+  background: #3498db;
+  text-decoration: underline;
+}
+a:active {
+  color: #ffd200;
+}
+```
+
+### Usage & Best Practices
+
+- Always provide a visible focus style for accessibility.
+- Use `:hover` and `:focus` together for consistent mouse and keyboard experience.
+- Style `:visited` to help users distinguish visited links.
+- Avoid removing underline unless you provide another clear indicator.
+- Anchor states can be combined with classes for custom buttons (see the back button on the [Anchor States Example Page](./HTML/anchor-state.html)).
+
+### Reference
+See the updated [anchor-state.html](./HTML/anchor-state.html) page for a live example of anchor styling and interactive navigation.
+
+---
+
 ## ✅ Summary Tips
 - Use an **external CSS** file for scalability.
 - Organize your CSS with **clear comments** and **consistent naming conventions**.

--- a/Summary.md
+++ b/Summary.md
@@ -631,7 +631,7 @@ ul.shorthand-list { list-style: square inside url('https://img.icons8.com/color/
 
 ---
 
-## 15. CSS Display Property
+## 16. CSS Display Property
 
 The `display` property in CSS is fundamental for controlling how elements are rendered and participate in the document layout. It determines whether an element behaves as a block, inline, inline-block, or is removed from the flow entirely.
 
@@ -673,7 +673,7 @@ See the updated [display.html](./HTML/display.html) page for a live example of t
 
 ---
 
-## 16. CSS Anchor States (Links)
+## 17. CSS Anchor States (Links)
 
 CSS anchors (links) are styled using pseudo-classes to reflect their different states: normal, visited, hover, active, and focus. Understanding and styling these states is essential for usability, accessibility, and visual feedback.
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
         <li><a href="HTML/drop-shadow.html">CSS Drop Shadow</a></li>
         <li><a href="HTML/filters.html">CSS Filters</a></li>
         <li><a href="HTML/list.html">CSS Lists</a></li>
-
+        <li><a href="HTML/display.html">CSS Display</a></li>
+        <li><a href="HTML/anchor-state.html">CSS Anchor State</a></li>
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add new demo pages for CSS display property and anchor states, including:
- HTML pages with interactive examples
- CSS styling for each demo
- Documentation in Summary.md
- Navigation links in index.html