### PR TITLE
feat(css): add CSS positioning and z-index documentation and demos

### DIFF
--- a/CSS/positions.css
+++ b/CSS/positions.css
@@ -1,0 +1,522 @@
+/* positions.css: Styles for the CSS position property demo page */
+
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+
+h1 {
+  text-align: center;
+  color: #3498db;
+  margin-bottom: 16px;
+}
+
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+
+/* Theory Diagrams */
+.theory-diagrams {
+  display: flex;
+  gap: 1.2rem;
+  margin: 1.5rem 0 2rem 0;
+  flex-wrap: wrap;
+}
+.diagram-card {
+  background: #f6f8fa;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(52,152,219,0.08);
+  padding: 0.7rem 1.2rem 1.2rem 1.2rem;
+  min-width: 110px;
+  text-align: center;
+  flex: 1 1 120px;
+}
+.diagram-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #3498db;
+  margin-bottom: 0.5rem;
+  display: block;
+}
+.diagram-static, .diagram-relative, .diagram-absolute, .diagram-fixed, .diagram-sticky {
+  width: 60px; height: 40px;
+  margin: 0 auto;
+  border-radius: 6px;
+  background: #e1eafc;
+  position: relative;
+}
+.diagram-static::after {
+  content: '';
+  display: block;
+  width: 30px; height: 18px;
+  background: #3498db;
+  border-radius: 4px;
+  margin: 10px auto 0 auto;
+}
+.diagram-relative::after {
+  content: '';
+  display: block;
+  width: 30px; height: 18px;
+  background: #27ae60;
+  border-radius: 4px;
+  margin: 10px 0 0 15px;
+  position: relative;
+  left: 10px;
+}
+.diagram-absolute::after {
+  content: '';
+  display: block;
+  width: 30px; height: 18px;
+  background: #e67e22;
+  border-radius: 4px;
+  margin: 0;
+  position: absolute;
+  top: 5px; right: 5px;
+}
+.diagram-fixed::after {
+  content: '';
+  display: block;
+  width: 30px; height: 18px;
+  background: #8e44ad;
+  border-radius: 4px;
+  margin: 0;
+  position: absolute;
+  top: 5px; left: 5px;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #8e44ad33;
+}
+.diagram-sticky::after {
+  content: '';
+  display: block;
+  width: 30px; height: 18px;
+  background: #f39c12;
+  border-radius: 4px;
+  margin: 0;
+  position: absolute;
+  top: 0; left: 15px;
+  box-shadow: 0 2px 8px #f39c1233;
+}
+
+/* Demos Layout */
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+.demo-card {
+  background: #fafdff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(52,152,219,0.10);
+  padding: 1.2rem 1.2rem 1.5rem 1.2rem;
+  min-width: 220px;
+  flex: 1 1 260px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.demo-label {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #3498db;
+  margin-bottom: 0.5rem;
+}
+.demo-box {
+  background: #e1eafc;
+  border-radius: 8px;
+  padding: 1.1rem 1.5rem;
+  font-size: 1.08rem;
+  margin-bottom: 0.7rem;
+  min-width: 120px;
+  text-align: center;
+}
+.demo-desc {
+  font-size: 0.98rem;
+  color: #555;
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+/* Static Demo */
+.static-demo .demo-box {
+  background: #e1eafc;
+}
+
+/* Relative Demo */
+.relative-demo .demo-box {
+  background: #d4efdf;
+  position: relative;
+  left: 18px;
+  top: 8px;
+}
+
+/* Absolute Demo */
+.absolute-demo {
+  position: relative;
+}
+.absolute-demo .demo-box {
+  background: #fdebd0;
+}
+.absolute-demo .overlay-btn {
+  margin: 0.5rem 0 0.2rem 0;
+  padding: 0.4rem 1.1rem;
+  border-radius: 6px;
+  border: none;
+  background: #3498db;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.absolute-demo .overlay-btn:focus,
+.absolute-demo .overlay-btn:hover {
+  background: #217dbb;
+  outline: 2px solid #217dbb;
+}
+.absolute-demo .overlay {
+  display: none;
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(52,152,219,0.15);
+  border-radius: 10px;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  flex-direction: column;
+}
+.absolute-demo .overlay span {
+  background: #3498db;
+  color: #fff;
+  padding: 0.7rem 1.2rem;
+  border-radius: 8px;
+  font-size: 1.05rem;
+  margin-bottom: 0.7rem;
+}
+.absolute-demo .close-overlay {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 2rem; height: 2rem;
+  font-size: 1.3rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.absolute-demo .close-overlay:focus,
+.absolute-demo .close-overlay:hover {
+  background: #c0392b;
+  outline: 2px solid #c0392b;
+}
+
+/* Absolute Demo Improvements */
+.abs-parent {
+  position: relative;
+  background: #f6f8fa;
+  border: 2px solid #b2bec3;
+  border-radius: 8px;
+  margin: 0.7rem 0 0.3rem 0;
+  min-height: 70px;
+  width: 210px;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.abs-parent-label {
+  position: absolute;
+  left: 10px; top: 6px;
+  font-size: 0.92rem;
+  color: #636e72;
+  background: #fff;
+  padding: 0 6px;
+  z-index: 2;
+  border-radius: 4px;
+}
+.abs-parent-rel {
+  position: relative;
+}
+.abs-parent-static {
+  position: static;
+}
+.abs-child {
+  position: absolute;
+  padding: 0.5rem 1.1rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 2px 8px #e67e2244;
+}
+.abs-child-1 {
+  background: #ffd200;
+  color: #222;
+  top: 12px;
+  right: 12px;
+}
+.abs-child-2 {
+  background: #ff9800;
+  color: #fff;
+  top: 12px;
+  left: 12px;
+}
+.abs-desc {
+  font-size: 0.95rem;
+  color: #888;
+  margin-bottom: 0.7rem;
+  margin-top: 0.1rem;
+  text-align: left;
+}
+
+/* Fixed Demo */
+.fixed-demo .demo-box {
+  background: #e8daef;
+}
+.fixed-demo .notify-btn {
+  margin: 0.5rem 0 0.2rem 0;
+  padding: 0.4rem 1.1rem;
+  border-radius: 6px;
+  border: none;
+  background: #8e44ad;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.fixed-demo .notify-btn:focus,
+.fixed-demo .notify-btn:hover {
+  background: #5e3370;
+  outline: 2px solid #5e3370;
+}
+.fixed-demo .fixed-notification {
+  display: none;
+  position: fixed;
+  top: 1.5rem; right: 1.5rem;
+  background: #8e44ad;
+  color: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 12px #8e44ad33;
+  z-index: 100;
+  align-items: center;
+  gap: 1rem;
+  flex-direction: row;
+}
+.fixed-demo .close-notify {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 2rem; height: 2rem;
+  font-size: 1.3rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.fixed-demo .close-notify:focus,
+.fixed-demo .close-notify:hover {
+  background: #c0392b;
+  outline: 2px solid #c0392b;
+}
+
+/* Sticky Demo */
+.sticky-demo {
+  max-height: 220px;
+  overflow-y: auto;
+  background: #f9e79f;
+}
+.sticky-demo .sticky-header {
+  position: sticky;
+  top: 0;
+  background: #f39c12;
+  color: #fff;
+  padding: 10px 0;
+  text-align: center;
+  font-weight: bold;
+  z-index: 10;
+  border-radius: 8px 8px 0 0;
+  box-shadow: 0 2px 8px #f39c1233;
+}
+.sticky-demo .demo-box {
+  background: #f7dc6f;
+}
+
+/* Sticky Demo Improvements */
+.sticky-demo {
+  max-height: 320px;
+  overflow-y: auto;
+  background: #f9e79f;
+  position: relative;
+}
+.sticky-scroll-content {
+  padding: 0.7rem 0.5rem 1.2rem 0.5rem;
+}
+.sticky-header {
+  position: sticky;
+  top: 0;
+  background: #f39c12;
+  color: #fff;
+  padding: 10px 0;
+  text-align: center;
+  font-weight: bold;
+  z-index: 10;
+  border-radius: 8px 8px 0 0;
+  box-shadow: 0 2px 8px #f39c1233;
+  transition: box-shadow 0.2s, background 0.2s;
+}
+.sticky-header.stuck {
+  background: #d35400;
+  box-shadow: 0 4px 16px #d3540033;
+}
+
+/* Tooltip Demo */
+.tooltip-demo {
+  position: relative;
+  outline: none;
+}
+.tooltip-demo .tooltip-btn {
+  margin: 0.5rem 0 0.2rem 0;
+  padding: 0.4rem 1.1rem;
+  border-radius: 6px;
+  border: none;
+  background: #23272e;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.tooltip-demo .tooltip-btn:focus,
+.tooltip-demo .tooltip-btn:hover {
+  background: #444b58;
+  outline: 2px solid #23272e;
+}
+.tooltip-demo .tooltip {
+  position: absolute;
+  bottom: 120%; left: 50%;
+  transform: translateX(-50%);
+  background: #23272e;
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.98rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 3;
+  white-space: nowrap;
+}
+.tooltip-demo:focus-within .tooltip,
+.tooltip-demo:hover .tooltip {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Z-Index Demo */
+.zindex-demo .z-stack {
+  position: relative;
+  width: 120px; height: 90px;
+  margin: 0 auto 0.7rem auto;
+}
+.zindex-demo .z-box {
+  position: absolute;
+  width: 80px; height: 40px;
+  left: 20px;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.85;
+  transition: box-shadow 0.2s, opacity 0.2s;
+  cursor: pointer;
+}
+.zindex-demo .z1 {
+  top: 0;
+  background: #3498db;
+  z-index: 1;
+}
+.zindex-demo .z2 {
+  top: 20px;
+  background: #e67e22;
+  z-index: 2;
+}
+zindex-demo .z3 {
+  top: 40px;
+  background: #8e44ad;
+  z-index: 3;
+}
+.zindex-demo .z-box:hover {
+  box-shadow: 0 0 0 4px #fff, 0 0 0 8px #3498db33;
+  opacity: 1;
+}
+
+/* Code Block Styling */
+.code-block {
+  background: #23272e;
+  color: #f8f8f2;
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  margin: 1.2rem 0;
+  overflow-x: auto;
+  font-size: 1.01rem;
+}
+.code-block code {
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  color: #f8f8f2;
+}
+
+/* Back Button */
+.back-btn {
+  display: inline-block;
+  margin: 2.5rem 0 0 0;
+  padding: 0.6rem 1.3rem;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 1.08rem;
+  box-shadow: 0 2px 8px #3498db22;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.back-btn:focus, .back-btn:hover {
+  background: linear-gradient(90deg, #217dbb 60%, #5e3370 100%);
+  box-shadow: 0 4px 16px #8e44ad33;
+  outline: 2px solid #217dbb;
+}
+
+/* Accessibility */
+:focus {
+  outline: 2px solid #3498db;
+  outline-offset: 2px;
+}
+
+@media (max-width: 900px) {
+  .demo-row, .theory-diagrams {
+    flex-direction: column;
+    gap: 1.2rem;
+  }
+  .demo-card, .diagram-card {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/CSS/z-index.css
+++ b/CSS/z-index.css
@@ -1,0 +1,216 @@
+/* z-index.css: Styles for the CSS z-index demo page */
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+h1 {
+  text-align: center;
+  color: #8e44ad;
+  margin-bottom: 16px;
+}
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+.code-block {
+  background: #181a20;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  margin-top: 10px;
+}
+.code-block code {
+  color: #ffd200;
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  font-size: 1rem;
+}
+.demo-section {
+  background: #f7f9fb;
+}
+.z-demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 18px;
+}
+.z-demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.08);
+  padding: 12px 10px 10px 10px;
+  min-width: 260px;
+  min-height: 200px;
+  transition: box-shadow 0.3s, transform 0.2s;
+  margin-bottom: 8px;
+  position: relative;
+}
+.z-demo-card:hover, .z-demo-card:focus-within {
+  box-shadow: 0 8px 32px 0 #8e44ad44;
+  transform: translateY(-4px) scale(1.04);
+}
+.z-demo-label {
+  font-weight: 600;
+  color: #8e44ad;
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+}
+.z-stack-demo {
+  position: relative;
+  width: 180px;
+  height: 120px;
+  margin: 0 auto 0.7rem auto;
+}
+.z-box {
+  position: absolute;
+  width: 110px;
+  height: 60px;
+  left: 35px;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.92;
+  transition: box-shadow 0.2s, opacity 0.2s, outline 0.2s;
+  cursor: pointer;
+  outline: 2px solid transparent;
+  font-size: 1.08rem;
+  z-index: auto;
+}
+.z1 { top: 0; background: #3498db; }
+.z2 { top: 25px; background: #e67e22; }
+.z3 { top: 50px; background: #8e44ad; }
+.z-box:hover {
+  box-shadow: 0 0 0 4px #fff, 0 0 0 8px #8e44ad33;
+  opacity: 1;
+  outline: 2px solid #ffd200;
+  z-index: 99 !important;
+}
+/* z-index stacking demo: override z-index for demo */
+.zindex-stack .z1 { z-index: 1; }
+.zindex-stack .z2 { z-index: 3; }
+.zindex-stack .z3 { z-index: 2; }
+/* parent stacking context demo */
+.parent-context {
+  width: 220px;
+  height: 120px;
+}
+.z-parent {
+  position: relative;
+  width: 120px;
+  height: 80px;
+  background: #d6eaf8;
+  border-radius: 8px;
+  left: 10px;
+  top: 20px;
+  z-index: 10;
+  box-shadow: 0 2px 8px #3498db22;
+}
+.z-parent-label {
+  position: absolute;
+  left: 8px; top: 4px;
+  font-size: 0.92rem;
+  color: #636e72;
+  background: #fff;
+  padding: 0 6px;
+  z-index: 2;
+  border-radius: 4px;
+}
+.z-child {
+  position: absolute;
+  top: 30px;
+  left: 30px;
+  width: 70px;
+  height: 36px;
+  background: #ffd200;
+  color: #222;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.98rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px #e67e2244;
+  z-index: 2;
+}
+.z-outside {
+  position: absolute;
+  top: 10px;
+  left: 120px;
+  width: 80px;
+  height: 60px;
+  background: #e74c3c;
+  color: #fff;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.98rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px #e74c3c44;
+  z-index: 5;
+}
+.z-demo-desc {
+  color: #888;
+  font-size: 0.98rem;
+  margin-top: 8px;
+  text-align: center;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 22px;
+  background: linear-gradient(90deg, #8e44ad 60%, #3498db 100%);
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.12);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+.back-btn:hover, .back-btn:focus {
+  background: linear-gradient(90deg, #3498db 0%, #8e44ad 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+@media (max-width: 700px) {
+  .container {
+    padding: 10px 2vw;
+  }
+  .z-demo-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .z-demo-card {
+    min-width: 0;
+    width: 100%;
+  }
+}
+:focus {
+  outline: 2px solid #8e44ad;
+  outline-offset: 2px;
+}

--- a/HTML/positions.html
+++ b/HTML/positions.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="CSS Position Property: static, relative, absolute, fixed, sticky - Theory, Examples, and Demos">
+  <title>CSS Position Property</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/positions.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>position</code> Property</h1>
+    <section class="theory-section">
+      <h2>Theory & Deep Explanation</h2>
+      <p>The <strong>position</strong> property in CSS is fundamental for controlling layout, stacking, and advanced UI effects. It determines how an element is placed in the document, how it interacts with other elements, and how it responds to scrolling and resizing. Understanding each value is key to mastering modern web design.</p>
+      <ul class="position-types-list">
+        <li><strong>static</strong>: <span class="theory-highlight">Default</span>. Element follows the normal document flow. <em>Offsets (top/right/bottom/left) and z-index have no effect.</em></li>
+        <li><strong>relative</strong>: Element is positioned relative to its normal spot. Offsets move it visually, but its original space is preserved. Useful for fine-tuning or as a reference for absolutely positioned children.</li>
+        <li><strong>absolute</strong>: Removed from the normal flow and positioned relative to the nearest ancestor with a position other than static. Great for overlays, tooltips, and dropdowns.</li>
+        <li><strong>fixed</strong>: Removed from flow and positioned relative to the viewport. Stays visible during scroll. Used for sticky navbars, notifications, or floating buttons.</li>
+        <li><strong>sticky</strong>: Acts as relative until a scroll threshold, then becomes fixed at the specified offset. Perfect for sticky headers, menus, or call-to-action boxes.</li>
+      </ul>
+      <div class="theory-diagrams">
+        <div class="diagram-card">
+          <span class="diagram-label">static</span>
+          <div class="diagram-static"></div>
+        </div>
+        <div class="diagram-card">
+          <span class="diagram-label">relative</span>
+          <div class="diagram-relative"></div>
+        </div>
+        <div class="diagram-card">
+          <span class="diagram-label">absolute</span>
+          <div class="diagram-absolute"></div>
+        </div>
+        <div class="diagram-card">
+          <span class="diagram-label">fixed</span>
+          <div class="diagram-fixed"></div>
+        </div>
+        <div class="diagram-card">
+          <span class="diagram-label">sticky</span>
+          <div class="diagram-sticky"></div>
+        </div>
+      </div>
+      <h3>Real-World Use Cases</h3>
+      <ul>
+        <li><strong>static</strong>: Most content blocks, paragraphs, and lists.</li>
+        <li><strong>relative</strong>: Nudge icons, badges, or create a reference for absolutely positioned children.</li>
+        <li><strong>absolute</strong>: Dropdown menus, popovers, tooltips, modals, and image overlays.</li>
+        <li><strong>fixed</strong>: Sticky navbars, floating action buttons, persistent notifications.</li>
+        <li><strong>sticky</strong>: Section headers, table headers, floating call-to-action bars.</li>
+      </ul>
+      <h3>Accessibility & Best Practices</h3>
+      <ul>
+        <li>Use <code>position: relative</code> for layout tweaks and as a positioning context for children.</li>
+        <li>Use <code>absolute</code> and <code>fixed</code> for overlays, tooltips, and UI elements that must float above content.</li>
+        <li>Test on different screen sizes and with keyboard navigation. Ensure overlays and tooltips are accessible.</li>
+        <li>Use <code>z-index</code> to manage stacking order, but avoid excessive stacking contexts.</li>
+      </ul>
+    </section>
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block"><pre><code>/* Overlay Example */
+.overlay-demo {
+  position: relative;
+}
+.overlay-demo .overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(52,152,219,0.15);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 2;
+}
+
+/* Tooltip Example */
+.tooltip-demo {
+  position: relative;
+}
+.tooltip-demo .tooltip {
+  position: absolute;
+  bottom: 120%; left: 50%;
+  transform: translateX(-50%);
+  background: #23272e; color: #fff;
+  padding: 6px 14px; border-radius: 6px;
+  font-size: 0.98rem;
+  opacity: 0; pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 3;
+}
+.tooltip-demo:focus-within .tooltip,
+.tooltip-demo:hover .tooltip {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Sticky Header Example */
+.sticky-header {
+  position: sticky;
+  top: 0;
+  background: #3498db;
+  color: #fff;
+  padding: 10px 0;
+  text-align: center;
+  font-weight: bold;
+  z-index: 10;
+}
+</code></pre></div>
+    </section>
+    <section class="demo-section">
+      <h2>Interactive Demos</h2>
+      <div class="demo-row">
+        <div class="demo-card static-demo">
+          <span class="demo-label">static</span>
+          <div class="demo-box">Static (default)</div>
+          <div class="demo-desc">Follows normal flow. No offset or stacking.</div>
+        </div>
+        <div class="demo-card relative-demo">
+          <span class="demo-label">relative</span>
+          <div class="demo-box">Relative (moved)</div>
+          <div class="demo-desc">Moved visually, but space is preserved.</div>
+        </div>
+        <div class="demo-card absolute-demo">
+          <span class="demo-label">absolute</span>
+          <div class="abs-parent abs-parent-rel">
+            <span class="abs-parent-label">Parent (relative)</span>
+            <div class="abs-child abs-child-1">Child (absolute)</div>
+          </div>
+          <div class="abs-desc">The yellow child is <b>position: absolute</b> inside a <b>position: relative</b> parent. It is placed at <b>top: 12px; right: 12px</b> of the parent.</div>
+          <div class="abs-parent abs-parent-static">
+            <span class="abs-parent-label">Parent (static)</span>
+            <div class="abs-child abs-child-2">Child (absolute)</div>
+          </div>
+          <div class="abs-desc">The orange child is <b>position: absolute</b> inside a <b>static</b> parent. It is placed at <b>top: 12px; left: 12px</b> of the <b>page</b> (initial containing block).</div>
+        </div>
+        <div class="demo-card fixed-demo">
+          <span class="demo-label">fixed</span>
+          <div class="demo-box">Fixed (scroll me!)</div>
+          <button class="notify-btn" aria-controls="fixed-notify" aria-expanded="false">Show Notification</button>
+          <div class="fixed-notification" id="fixed-notify" tabindex="-1" aria-hidden="true">
+            <span>This is a fixed notification!</span>
+            <button class="close-notify" aria-label="Close notification">×</button>
+          </div>
+          <div class="demo-desc">Stays visible on scroll. Try the notification.</div>
+        </div>
+        <div class="demo-card sticky-demo">
+          <span class="demo-label">sticky</span>
+          <div class="sticky-header sticky-indicator" id="sticky-header">Sticky Header (scroll this card)</div>
+          <div class="demo-box">Sticky (scroll inside)</div>
+          <div class="sticky-scroll-content">
+            <p>Scroll down to see the header stick to the top of this card. The sticky header will highlight when it becomes fixed.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur.</p>
+            <p>Aliquam erat volutpat. Etiam nec velit nec nulla dictum dictum. Suspendisse potenti.</p>
+            <p>Vivamus euismod, urna eu tincidunt consectetur, nisi nisl aliquam nunc, eget aliquam nisl nunc eu nisl.</p>
+            <p>More content to enable scrolling...</p>
+            <p>Even more content to enable scrolling...</p>
+          </div>
+          <div class="demo-desc">Scroll this card to see sticky in action. The header will highlight when sticky.</div>
+        </div>
+        <div class="demo-card tooltip-demo" tabindex="0">
+          <span class="demo-label">tooltip</span>
+          <button class="tooltip-btn">Hover or focus me</button>
+          <div class="tooltip">Tooltip using <code>position: absolute</code></div>
+          <div class="demo-desc">Accessible tooltip appears on hover/focus.</div>
+        </div>
+        <div class="demo-card zindex-demo">
+          <span class="demo-label">z-index</span>
+          <div class="z-stack">
+            <div class="z-box z1">z-index: 1</div>
+            <div class="z-box z2">z-index: 2</div>
+            <div class="z-box z3">z-index: 3</div>
+          </div>
+          <div class="demo-desc">Stacking context demo. Hover to highlight.</div>
+        </div>
+      </div>
+      <p class="demo-desc">Try scrolling, resizing, and interacting with the demos to see how <code>position</code> changes layout and behavior.</p>
+    </section>
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+  <script>
+    // Overlay demo
+    document.addEventListener('DOMContentLoaded', function() {
+      var overlayBtn = document.querySelector('.absolute-demo .overlay-btn');
+      var overlay = document.getElementById('abs-overlay');
+      var closeOverlay = document.querySelector('.absolute-demo .close-overlay');
+      if (overlayBtn && overlay && closeOverlay) {
+        overlayBtn.addEventListener('click', function() {
+          overlay.style.display = 'flex';
+          overlay.setAttribute('aria-hidden', 'false');
+          overlayBtn.setAttribute('aria-expanded', 'true');
+          overlay.focus();
+        });
+        closeOverlay.addEventListener('click', function() {
+          overlay.style.display = 'none';
+          overlay.setAttribute('aria-hidden', 'true');
+          overlayBtn.setAttribute('aria-expanded', 'false');
+          overlayBtn.focus();
+        });
+      }
+      // Fixed notification demo
+      var notifyBtn = document.querySelector('.fixed-demo .notify-btn');
+      var notify = document.getElementById('fixed-notify');
+      var closeNotify = document.querySelector('.fixed-demo .close-notify');
+      if (notifyBtn && notify && closeNotify) {
+        notifyBtn.addEventListener('click', function() {
+          notify.style.display = 'flex';
+          notify.setAttribute('aria-hidden', 'false');
+          notifyBtn.setAttribute('aria-expanded', 'true');
+          notify.focus();
+        });
+        closeNotify.addEventListener('click', function() {
+          notify.style.display = 'none';
+          notify.setAttribute('aria-hidden', 'true');
+          notifyBtn.setAttribute('aria-expanded', 'false');
+          notifyBtn.focus();
+        });
+      }
+      // Sticky header highlight
+      var stickyDemo = document.querySelector('.sticky-demo');
+      var stickyHeader = document.getElementById('sticky-header');
+      if (stickyDemo && stickyHeader) {
+        stickyDemo.addEventListener('scroll', function() {
+          var rect = stickyHeader.getBoundingClientRect();
+          var parentRect = stickyDemo.getBoundingClientRect();
+          if (rect.top <= parentRect.top) {
+            stickyHeader.classList.add('stuck');
+          } else {
+            stickyHeader.classList.remove('stuck');
+          }
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/HTML/z-index.html
+++ b/HTML/z-index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="In-depth CSS z-index theory, interactive examples, and best practices.">
+  <title>CSS z-index: Theory & Interactive Examples</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/z-index.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>z-index</code></h1>
+    <section class="theory-section">
+      <h2>Theory & Explanation</h2>
+      <p><strong>z-index</strong> is a CSS property that controls the vertical stacking order of positioned elements (those with <code>position</code> set to <code>relative</code>, <code>absolute</code>, <code>fixed</code>, or <code>sticky</code>). Elements with a higher <code>z-index</code> value appear in front of those with a lower value. <code>z-index</code> only works on elements that create a stacking context.</p>
+      <ul>
+        <li><strong>Default stacking:</strong> Elements are stacked in the order they appear in the HTML (later elements on top).</li>
+        <li><strong>z-index:</strong> Assigns a stacking level. Higher values are closer to the viewer.</li>
+        <li><strong>Stacking context:</strong> Created by elements with <code>position</code> (not static) and a <code>z-index</code> value, <code>opacity &lt; 1</code>, <code>transform</code>, <code>filter</code>, <code>will-change</code>, <code>mix-blend-mode</code>, etc.</li>
+        <li><strong>Nested stacking:</strong> Each stacking context is independent; child z-index values are relative to their parent context.</li>
+      </ul>
+      <h3>When to Use z-index</h3>
+      <ul>
+        <li>To control which overlay, modal, tooltip, or dropdown appears above others.</li>
+        <li>To resolve stacking issues with positioned elements.</li>
+        <li>To create layered UI effects (cards, popups, sticky headers, etc.).</li>
+      </ul>
+      <h3>Best Practices</h3>
+      <ul>
+        <li>Use the smallest z-index values needed to avoid confusion.</li>
+        <li>Minimize the number of stacking contexts for easier debugging.</li>
+        <li>Document z-index values in your codebase for maintainability.</li>
+      </ul>
+    </section>
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block">
+<pre><code>/* Basic z-index */
+.box1 { z-index: 1; }
+.box2 { z-index: 2; }
+
+/* Stacking context */
+.parent {
+  position: relative;
+  z-index: 10;
+}
+.child {
+  position: absolute;
+  z-index: 2;
+}
+</code></pre>
+      </div>
+    </section>
+    <section class="demo-section">
+      <h2>Interactive Demos</h2>
+      <div class="z-demo-row">
+        <div class="z-demo-card">
+          <span class="z-demo-label">Default stacking (no z-index)</span>
+          <div class="z-stack-demo default-stack">
+            <div class="z-box z1">Box 1</div>
+            <div class="z-box z2">Box 2</div>
+            <div class="z-box z3">Box 3</div>
+          </div>
+          <div class="z-demo-desc">Later elements appear on top by default.</div>
+        </div>
+        <div class="z-demo-card">
+          <span class="z-demo-label">z-index stacking</span>
+          <div class="z-stack-demo zindex-stack">
+            <div class="z-box z1" style="z-index:1;">z-index: 1</div>
+            <div class="z-box z2" style="z-index:3;">z-index: 3</div>
+            <div class="z-box z3" style="z-index:2;">z-index: 2</div>
+          </div>
+          <div class="z-demo-desc">Box with higher z-index appears on top, regardless of HTML order.</div>
+        </div>
+        <div class="z-demo-card">
+          <span class="z-demo-label">Stacking context (nested)</span>
+          <div class="z-stack-demo parent-context">
+            <div class="z-parent">
+              <span class="z-parent-label">Parent (z-index: 10)</span>
+              <div class="z-child" style="z-index: 2;">Child (z-index: 2)</div>
+            </div>
+            <div class="z-box z-outside" style="z-index: 5;">Outside (z-index: 5)</div>
+          </div>
+          <div class="z-demo-desc">Child's z-index is relative to its parent stacking context, not the page.</div>
+        </div>
+      </div>
+      <p class="z-demo-desc">Hover over the boxes to see their stacking visually. Try changing the z-index values in the code for different effects.</p>
+    </section>
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -717,6 +717,108 @@ See the updated [anchor-state.html](./HTML/anchor-state.html) page for a live ex
 
 ---
 
+## 18. CSS Position Property
+
+The <strong>position</strong> property in CSS controls how elements are placed in the document flow. It enables you to move, layer, and fix elements in place, making it essential for layouts, overlays, tooltips, sticky headers, and more.
+
+### Position Values
+
+- <strong>static</strong>: Default. Elements are positioned according to the normal document flow. <em>Offsets (top, right, bottom, left, z-index) have no effect.</em>
+- <strong>relative</strong>: The element is positioned relative to its normal position. Offsets move it visually, but its original space is preserved.
+- <strong>absolute</strong>: The element is removed from the normal flow and positioned relative to the nearest ancestor with a position other than static. If none, it uses the viewport.
+- <strong>fixed</strong>: The element is removed from the flow and positioned relative to the viewport. It stays fixed when scrolling.
+- <strong>sticky</strong>: The element toggles between relative and fixed, depending on the scroll position. It "sticks" to a given offset as you scroll.
+
+### Example
+
+```css
+.static-demo .demo-box {
+  position: static;
+}
+.relative-demo .demo-box {
+  position: relative;
+  left: 24px;
+  top: 10px;
+}
+.absolute-demo {
+  position: relative;
+}
+.absolute-demo .demo-box {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+}
+.fixed-demo .demo-box {
+  position: fixed;
+  top: 32px;
+  right: 32px;
+}
+.sticky-demo .demo-box {
+  position: sticky;
+  top: 8px;
+}
+```
+
+### Usage & Best Practices
+
+- Use <code>position: relative</code> for fine-tuning layout without removing elements from the flow.
+- Use <code>absolute</code> and <code>fixed</code> for overlays, tooltips, or UI elements that must float.
+- <code>sticky</code> is great for headers, menus, or call-to-action boxes that should remain visible while scrolling.
+- Always test on different screen sizes and with keyboard navigation.
+- Avoid overusing <code>absolute</code> and <code>fixed</code> as they can break responsive layouts.
+
+### Reference
+See the updated [positions.html](./HTML/positions.html) page for a live example of the CSS position property, theory, and interactive demos.
+
+---
+
+## 19. z-index in CSS
+
+The <strong>z-index</strong> property controls the vertical stacking order of positioned elements (those with <code>position: relative</code>, <code>absolute</code>, <code>fixed</code>, or <code>sticky</code>). Elements with a higher <code>z-index</code> value appear in front of those with a lower value. <code>z-index</code> only works on elements that create a stacking context.
+
+### How z-index Works
+- <strong>Default stacking:</strong> Elements are stacked in the order they appear in the HTML (later elements on top).
+- <strong>z-index:</strong> Assigns a stacking level. Higher values are closer to the viewer.
+- <strong>Stacking context:</strong> Created by elements with <code>position</code> (not static) and a <code>z-index</code> value, <code>opacity &lt; 1</code>, <code>transform</code>, <code>filter</code>, <code>will-change</code>, <code>mix-blend-mode</code>, etc.
+- <strong>Nested stacking:</strong> Each stacking context is independent; child z-index values are relative to their parent context.
+
+### Usage & Best Practices
+- Use <code>z-index</code> to control overlays, modals, tooltips, dropdowns, and layered UI effects.
+- Use the smallest values needed to avoid confusion.
+- Minimize stacking contexts for easier debugging.
+- Document z-index values in your codebase for maintainability.
+
+### Example:
+```css
+/* Basic z-index */
+.box1 { z-index: 1; }
+.box2 { z-index: 2; }
+
+/* Stacking context */
+.parent {
+  position: relative;
+  z-index: 10;
+}
+.child {
+  position: absolute;
+  z-index: 2;
+}
+```
+
+### Interactive Example
+See <strong>z-index.html</strong> for interactive demos:
+- Default stacking (no z-index): later elements appear on top.
+- z-index stacking: higher z-index appears on top, regardless of HTML order.
+- Stacking context: child z-index is relative to its parent context, not the page.
+
+[View the interactive z-index demo page &rarr;](HTML/z-index.html)
+
+### Browser Compatibility
+- <strong>z-index</strong> is supported in all modern browsers (Chrome, Firefox, Edge, Safari, Opera).
+- For best results, always use <code>position</code> (not static) with <code>z-index</code>.
+
+---
+
 ## ✅ Summary Tips
 - Use an **external CSS** file for scalability.
 - Organize your CSS with **clear comments** and **consistent naming conventions**.

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
         <li><a href="HTML/list.html">CSS Lists</a></li>
         <li><a href="HTML/display.html">CSS Display</a></li>
         <li><a href="HTML/anchor-state.html">CSS Anchor State</a></li>
+        <li><a href="HTML/positions.html">CSS Positioning</a></li>
+        <li><a href="HTML/z-index.html">CSS Z-index</a></li>
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add new pages for CSS positioning (positions.html) and z-index (z-index.html) with comprehensive documentation, interactive demos, and styling. Include navigation links in index.html and update Summary.md with detailed explanations and examples.

The demos showcase static, relative, absolute, fixed, and sticky positioning with practical use cases. The z-index page demonstrates stacking contexts and vertical ordering with interactive examples. Both pages include accessibility considerations and best practices.