### PR TITLE
feat(css): add pseudo-elements demo page with interactive examples

### DIFF
--- a/CSS/psuedo-elements.css
+++ b/CSS/psuedo-elements.css
@@ -1,0 +1,237 @@
+/* psuedo-elements.css: Styles for the CSS pseudo-elements demo page */
+body {
+  background: linear-gradient(120deg, #f0f4f8 0%, #e0e7ef 100%);
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 32px 0 rgba(52, 152, 219, 0.10);
+  padding: 32px 24px 24px 24px;
+}
+h1 {
+  text-align: center;
+  color: #8e44ad;
+  margin-bottom: 16px;
+}
+.theory-section, .code-section, .demo-section {
+  margin-bottom: 32px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: #f8fafc;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.04);
+}
+.code-section {
+  background: #23272e;
+  color: #f8f8f2;
+}
+.code-block {
+  background: #181a20;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  margin-top: 10px;
+}
+.code-block code {
+  color: #ffd200;
+  font-family: 'Fira Mono', 'Consolas', monospace;
+  font-size: 1rem;
+}
+.demo-section {
+  background: #f7f9fb;
+}
+.pseudo-demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 18px;
+}
+.pseudo-demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.08);
+  padding: 12px 10px 10px 10px;
+  min-width: 260px;
+  min-height: 160px;
+  transition: box-shadow 0.3s, transform 0.2s;
+  margin-bottom: 8px;
+  position: relative;
+}
+.pseudo-demo-card:hover, .pseudo-demo-card:focus-within {
+  box-shadow: 0 8px 32px 0 #8e44ad44;
+  transform: translateY(-4px) scale(1.04);
+}
+.pseudo-demo-label {
+  font-weight: 600;
+  color: #8e44ad;
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+}
+.pseudo-btn {
+  font-size: 1.08rem;
+  padding: 10px 22px;
+  border-radius: 6px;
+  border: none;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 2px 8px #3498db22;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+.pseudo-btn:hover, .pseudo-btn:focus {
+  background: linear-gradient(90deg, #8e44ad 0%, #3498db 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+.pseudo-intro {
+  max-width: 220px;
+  margin: 0 auto;
+  font-size: 1.01rem;
+  line-height: 1.5;
+  background: #f7e9ff;
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.pseudo-selection {
+  max-width: 220px;
+  margin: 0 auto;
+  font-size: 1.01rem;
+  background: #eaf7ff;
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.pseudo-placeholder {
+  font-size: 1.08rem;
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 2px solid #8e44ad;
+  margin-top: 8px;
+  width: 180px;
+  background: #f8fafc;
+  color: #222;
+}
+.pseudo-list {
+  margin: 0 auto;
+  padding: 0 0 0 18px;
+  max-width: 220px;
+}
+.pseudo-list li {
+  margin: 6px 0;
+  padding: 6px 10px;
+  border-radius: 5px;
+  background: #f8fafc;
+  transition: background 0.2s, color 0.2s;
+}
+.pseudo-demo-desc {
+  color: #888;
+  font-size: 0.98rem;
+  margin-top: 8px;
+  text-align: center;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 22px;
+  background: linear-gradient(90deg, #8e44ad 60%, #3498db 100%);
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px 0 rgba(52, 152, 219, 0.12);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+.back-btn:hover, .back-btn:focus {
+  background: linear-gradient(90deg, #3498db 0%, #8e44ad 100%);
+  box-shadow: 0 4px 16px 0 #8e44ad44;
+  transform: translateY(-2px) scale(1.03);
+}
+/* Pseudo-element demos */
+.button::before { content: '🚀 '; }
+.button::after { content: ' →'; }
+.intro::first-letter { font-size: 2rem; color: #8e44ad; }
+.intro::first-line { font-weight: bold; }
+pseudo-selection::selection, .pseudo-selection::selection { background: #ffd200; color: #222; }
+input::placeholder, .pseudo-placeholder::placeholder { color: #888; font-style: italic; }
+.pseudo-list li:first-child { color: #3498db; }
+.pseudo-list li:last-child { color: #e67e22; }
+.pseudo-list li:nth-child(2) { font-weight: bold; }
+.pseudo-list li:only-child { color: #27ae60; }
+.pseudo-list li:empty { background: #f7e9ff; }
+/* Animated badge with ::after */
+.badge::after {
+  content: '●';
+  color: #e74c3c;
+  margin-left: 8px;
+  font-size: 1.2em;
+  animation: pulse 1.2s infinite alternate;
+}
+@keyframes pulse {
+  from { opacity: 0.5; transform: scale(1); }
+  to { opacity: 1; transform: scale(1.3); }
+}
+/* Custom list marker */
+ul.custom-list li::marker {
+  color: #3498db;
+  font-size: 1.2em;
+}
+/* Progress bar using ::before */
+.progress-bar {
+  position: relative;
+  background: #eee;
+  border-radius: 8px;
+  height: 18px;
+  width: 180px;
+  margin: 10px 0;
+  overflow: hidden;
+}
+.progress-bar::before {
+  content: '';
+  display: block;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  height: 100%;
+  border-radius: 8px 0 0 8px;
+  width: 60%;
+  transition: width 0.5s;
+}
+/* Custom placeholder and selection */
+input::placeholder {
+  color: #8e44ad;
+  font-style: italic;
+  opacity: 0.8;
+}
+input:focus::placeholder {
+  color: #3498db;
+  opacity: 1;
+}
+input::selection {
+  background: #ffd200;
+  color: #222;
+}
+@media (max-width: 700px) {
+  .container {
+    padding: 10px 2vw;
+  }
+  .pseudo-demo-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .pseudo-demo-card {
+    min-width: 0;
+    width: 100%;
+  }
+}
+:focus {
+  outline: 2px solid #8e44ad;
+  outline-offset: 2px;
+}

--- a/HTML/psuedo-elements.html
+++ b/HTML/psuedo-elements.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="description" content="In-depth CSS pseudo-elements theory, interactive examples, and best practices.">
+  <title>CSS Pseudo-elements: Theory & Interactive Examples</title>
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/psuedo-elements.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>Pseudo-elements</code></h1>
+    <section class="theory-section">
+      <h2>Theory & Deep Explanation</h2>
+      <p><strong>Pseudo-elements</strong> in CSS are powerful tools that let you style specific parts of an element or insert content before or after it, without extra HTML. They enable advanced effects, custom highlights, and creative UI patterns, all while keeping your markup clean and semantic.</p>
+      <ul>
+        <li><strong>::before</strong> / <strong>::after</strong>: Insert generated content before/after the element's content. Great for icons, badges, or decorative elements.</li>
+        <li><strong>::first-letter</strong>: Style the first letter of a block element. Used for drop caps or magazine-style intros.</li>
+        <li><strong>::first-line</strong>: Style the first line of a block element. Useful for headlines or emphasis.</li>
+        <li><strong>::selection</strong>: Style the portion of text selected by the user. Enhances accessibility and branding.</li>
+        <li><strong>::placeholder</strong>: Style placeholder text in form fields. Improves form UX and branding.</li>
+        <li><strong>::marker</strong>: Style the bullet or number of list items. Allows for custom list styles.</li>
+        <li><strong>::backdrop</strong>: Style the background of modal elements (e.g., dialogs, popups).</li>
+        <li><strong>::file-selector-button</strong>: Style the button of file input fields for custom file upload UIs.</li>
+        <li><strong>::cue</strong>: Style WebVTT cues in media elements (advanced, for subtitles/captions).</li>
+        <li><strong>::part()</strong>: Style shadow DOM parts (advanced, for web components).</li>
+      </ul>
+      <h3>How Pseudo-elements Work</h3>
+      <ul>
+        <li>Pseudo-elements are not real DOM elements—they are rendered by the browser and cannot be selected with JavaScript.</li>
+        <li>They can be animated and transitioned for interactive effects.</li>
+        <li>They inherit styles from their parent unless overridden.</li>
+        <li>Some pseudo-elements (like <code>::before</code> and <code>::after</code>) require a <code>content</code> property to display.</li>
+      </ul>
+      <h3>Advanced Use Cases</h3>
+      <ul>
+        <li>Custom checkboxes, toggles, and switches using <code>::before</code> and <code>::after</code>.</li>
+        <li>Animated highlights, tooltips, and badges.</li>
+        <li>Accessible focus indicators and custom selection colors.</li>
+        <li>Decorative list markers and progress bars.</li>
+        <li>Styling form placeholders and file upload buttons for a consistent look.</li>
+      </ul>
+      <h3>Accessibility & Best Practices</h3>
+      <ul>
+        <li>Use pseudo-elements for decoration, not for essential content (screen readers may ignore them).</li>
+        <li>Always provide sufficient color contrast for <code>::selection</code> and <code>::placeholder</code>.</li>
+        <li>Test on different browsers for compatibility, especially with advanced pseudo-elements.</li>
+      </ul>
+    </section>
+    <section class="code-section">
+      <h2>Code Examples</h2>
+      <div class="code-block">
+<pre><code>/* Animated badge with ::after */
+.badge::after {
+  content: '●';
+  color: #e74c3c;
+  margin-left: 8px;
+  font-size: 1.2em;
+  animation: pulse 1.2s infinite alternate;
+}
+
+/* Custom list marker */
+ul.custom-list li::marker {
+  color: #3498db;
+  font-size: 1.2em;
+}
+
+/* Progress bar using ::before */
+.progress-bar {
+  position: relative;
+  background: #eee;
+  border-radius: 8px;
+  height: 18px;
+  width: 180px;
+  margin: 10px 0;
+}
+.progress-bar::before {
+  content: '';
+  display: block;
+  background: linear-gradient(90deg, #3498db 60%, #8e44ad 100%);
+  height: 100%;
+  border-radius: 8px 0 0 8px;
+  width: 60%;
+  transition: width 0.5s;
+}
+
+/* Custom placeholder and selection */
+input::placeholder {
+  color: #8e44ad;
+  font-style: italic;
+  opacity: 0.8;
+}
+input:focus::placeholder {
+  color: #3498db;
+  opacity: 1;
+}
+input::selection {
+  background: #ffd200;
+  color: #222;
+}
+</code></pre>
+      </div>
+    </section>
+    <section class="demo-section">
+      <h2>Interactive Demos</h2>
+      <div class="pseudo-demo-row">
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">Animated badge (::after)</span>
+          <span class="badge pseudo-badge">Notifications</span>
+          <div class="pseudo-demo-desc">A pulsing badge is added after the text using <code>::after</code>.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">Custom list marker (::marker)</span>
+          <ul class="custom-list">
+            <li>Blue marker</li>
+            <li>Another item</li>
+          </ul>
+          <div class="pseudo-demo-desc">List markers are styled with color and size.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">Progress bar (::before)</span>
+          <div class="progress-bar"></div>
+          <div class="pseudo-demo-desc">A progress bar is created using <code>::before</code>.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">::before &amp; ::after</span>
+          <button class="button pseudo-btn">Button</button>
+          <div class="pseudo-demo-desc">Decorative icons added before and after the button text.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">::first-letter &amp; ::first-line</span>
+          <p class="intro pseudo-intro">This paragraph demonstrates how you can style the <b>first letter</b> and <b>first line</b> of a block of text using pseudo-elements. Try resizing the box to see the effect.</p>
+          <div class="pseudo-demo-desc">First letter is large and colored, first line is bold.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">::selection</span>
+          <p class="pseudo-selection">Select some of this text to see a custom highlight color using <code>::selection</code>.</p>
+          <div class="pseudo-demo-desc">Try selecting the text above.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">::placeholder</span>
+          <input class="pseudo-placeholder" type="text" placeholder="Type here...">
+          <div class="pseudo-demo-desc">Placeholder text is styled with color and italics.</div>
+        </div>
+        <div class="pseudo-demo-card">
+          <span class="pseudo-demo-label">Structural pseudo-classes</span>
+          <ul class="pseudo-list">
+            <li>First item</li>
+            <li>Second item</li>
+            <li>Third item</li>
+            <li></li>
+          </ul>
+          <div class="pseudo-demo-desc">First, last, nth, only, and empty list items are styled differently.</div>
+        </div>
+      </div>
+      <p class="pseudo-demo-desc">Try interacting with the demos above to see how pseudo-elements and structural pseudo-classes work in practice.</p>
+    </section>
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </div>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -871,4 +871,60 @@ See **overflow.html** for interactive demos:
 
 ---
 
+## 21. Pseudo-elements in CSS
+
+**Pseudo-elements** allow you to style specific parts of an element or insert content before or after it, without extra HTML. They are written with a double colon (`::`) (e.g., `::before`), though single colon syntax is still supported for backward compatibility.
+
+### Common Pseudo-elements
+- `::before` / `::after`: Insert content before/after the element's content.
+- `::first-letter`: Style the first letter of a block element.
+- `::first-line`: Style the first line of a block element.
+- `::selection`: Style the portion of text selected by the user.
+- `::placeholder`: Style placeholder text in form fields.
+- `::marker`: Style the marker box of list items.
+- `::backdrop`: Style the background of modal elements.
+- `::file-selector-button`: Style the button of file input fields.
+- `::cue`: Style WebVTT cues in media elements.
+- `::part()`: Style shadow DOM parts (advanced).
+
+### Structural Pseudo-classes (for reference)
+- `:first-child`, `:last-child`, `:nth-child()`, `:nth-of-type()`, `:only-child`, `:empty` — Select elements based on their position or content in the DOM.
+
+### Usage & Best Practices
+- Use pseudo-elements to add icons, highlights, or effects without extra markup.
+- Use `::selection` for custom highlight colors.
+- Use `::placeholder` to style form hints.
+- Combine with transitions for interactive effects.
+
+### Example
+```css
+.button::before { content: '🚀 '; }
+.button::after { content: ' →'; }
+.intro::first-letter { font-size: 2rem; color: #8e44ad; }
+.intro::first-line { font-weight: bold; }
+p::selection { background: #ffd200; color: #222; }
+input::placeholder { color: #888; font-style: italic; }
+li:first-child { color: #3498db; }
+li:last-child { color: #e67e22; }
+li:nth-child(2) { font-weight: bold; }
+li:only-child { color: #27ae60; }
+li:empty { background: #f7e9ff; }
+```
+
+### Interactive Example
+See **psuedo-elements.html** for interactive demos:
+- `::before`/`::after` — add icons to a button.
+- `::first-letter`/`::first-line` — style the first letter/line of a paragraph.
+- `::selection` — custom highlight color.
+- `::placeholder` — style form placeholder text.
+- Structural pseudo-classes — style list items based on position/content.
+
+[View the interactive pseudo-elements demo page &rarr;](HTML/psuedo-elements.html)
+
+### Browser Compatibility
+- Most pseudo-elements are supported in all modern browsers (Chrome, Firefox, Edge, Safari, Opera).
+- Some advanced pseudo-elements (e.g., `::backdrop`, `::part()`) may have limited support.
+
+---
+
 _Keep updating this summary as you explore more advanced CSS concepts like animations, transitions, Flexbox, Grid, media queries, and preprocessors (like SASS)._ 🚀

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
         <li><a href="HTML/positions.html">CSS Positioning</a></li>
         <li><a href="HTML/z-index.html">CSS Z-index</a></li>
         <li><a href="HTML/overflow.html">CSS Overflow</a></li>
+        <li><a href="HTML/psuedo-elements.html">CSS Pseudo-elements</a></li>
+</li>
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add new HTML/CSS files for pseudo-elements demonstration including:
- Comprehensive documentation in Summary.md
- Interactive examples showcasing various pseudo-elements
- Styled demo cards with hover effects
- Responsive design for mobile devices