### PR TITLE
feat: add CSS pseudo-classes documentation and examples

### DIFF
--- a/CSS/pseudo-class.css
+++ b/CSS/pseudo-class.css
@@ -65,7 +65,7 @@ code {
   font-size: 1em;
 }
 /* Interactive Demos */
-.demo-btn {
+.demo-btn, .back-btn {
   display: inline-block;
   background: #ffd200;
   color: #8e44ad;
@@ -75,17 +75,27 @@ code {
   font-weight: bold;
   transition: background 0.2s, color 0.2s;
   margin-bottom: 0.5em;
+  box-shadow: 0 2px 8px rgba(52, 152, 219, 0.08);
 }
-.demo-btn:hover {
+.demo-btn:hover,
+.demo-btn:focus {
   background: #8e44ad;
   color: #fff;
-}
-.demo-btn:focus {
   outline: 2px solid #f7971e;
   outline-offset: 2px;
 }
 .demo-btn:active {
   background: #3498db;
+}
+ .back-btn{
+  margin-top: 2rem;
+ }
+.back-btn:hover,
+.back-btn:focus {
+  background: #8e44ad;
+  color: #fff;
+  outline: 2px solid #f7971e;
+  outline-offset: 2px;
 }
 .child-demo {
   display: flex;
@@ -135,6 +145,29 @@ code {
 .nth-demo li:nth-child(3) {
   color: #f7971e;
   font-weight: bold;
+}
+.nth-of-type-demo {
+  display: flex;
+  gap: 1em;
+  list-style: none;
+  padding: 0;
+  margin: 0.5em 0 0.5em 0;
+}
+.nth-of-type-demo li {
+  background: #e3f6fd;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+  color: #222;
+  font-weight: normal;
+  transition: background 0.2s, color 0.2s;
+}
+.nth-of-type-demo li:nth-of-type(2) {
+  background: #ffd200;
+  color: #8e44ad;
+}
+.nth-of-type-demo li:nth-of-type(3) {
+  background: #8e44ad;
+  color: #fff;
 }
 .empty-demo {
   display: flex;
@@ -220,25 +253,6 @@ code {
 .form-demo button:hover,
 .form-demo button:focus {
   background: #3498db;
-}
-.back-btn {
-  display: inline-block;
-  margin-top: 2rem;
-  background: #ffd200;
-  color: #8e44ad;
-  padding: 0.7em 1.5em;
-  border-radius: 6px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.2s, color 0.2s;
-  box-shadow: 0 2px 8px rgba(52, 152, 219, 0.08);
-}
-.back-btn:hover,
-.back-btn:focus {
-  background: #8e44ad;
-  color: #fff;
-  outline: 2px solid #f7971e;
-  outline-offset: 2px;
 }
 @media (max-width: 600px) {
   main {

--- a/CSS/pseudo-class.css
+++ b/CSS/pseudo-class.css
@@ -1,0 +1,253 @@
+/* Basic Reset & Layout */
+body {
+  font-family: 'Segoe UI', Arial, sans-serif;
+  background: linear-gradient(120deg, #f0e6fa 0%, #e3f6fd 100%);
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+header {
+  background: #8e44ad;
+  color: #fff;
+  padding: 2rem 1rem 1rem 1rem;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(52, 152, 219, 0.08);
+}
+.subtitle {
+  font-size: 1.2rem;
+  color: #ffd200;
+  margin-top: 0.5rem;
+}
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(52, 152, 219, 0.10);
+  padding: 2rem 1.5rem 3rem 1.5rem;
+}
+.theory-section, .best-practices {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e3f6fd;
+}
+.theory-section h2, .demo-section h2, .best-practices h2 {
+  color: #8e44ad;
+}
+.demo-section {
+  margin-bottom: 2.5rem;
+}
+.demo-block {
+  margin-bottom: 2rem;
+  padding: 1.2rem 1rem;
+  background: #f9f6ff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(52, 152, 219, 0.06);
+}
+.demo-block h3 {
+  margin-top: 0;
+  color: #3498db;
+}
+pre {
+  background: #222;
+  color: #ffd200;
+  padding: 0.8em 1em;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 0.98em;
+  margin-top: 1em;
+}
+code {
+  background: #f0e6fa;
+  color: #8e44ad;
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+  font-size: 1em;
+}
+/* Interactive Demos */
+.demo-btn {
+  display: inline-block;
+  background: #ffd200;
+  color: #8e44ad;
+  padding: 0.7em 1.5em;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background 0.2s, color 0.2s;
+  margin-bottom: 0.5em;
+}
+.demo-btn:hover {
+  background: #8e44ad;
+  color: #fff;
+}
+.demo-btn:focus {
+  outline: 2px solid #f7971e;
+  outline-offset: 2px;
+}
+.demo-btn:active {
+  background: #3498db;
+}
+.child-demo {
+  display: flex;
+  gap: 1em;
+  list-style: none;
+  padding: 0;
+  margin: 0.5em 0 0.5em 0;
+}
+.child-demo li {
+  background: #e3f6fd;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+  font-weight: normal;
+  color: #222;
+  transition: background 0.2s, color 0.2s;
+}
+.child-demo li:first-child {
+  color: #8e44ad;
+  font-weight: bold;
+}
+.child-demo li:last-child {
+  color: #3498db;
+}
+.child-demo.single li:only-child {
+  background: #ffd200;
+  color: #8e44ad;
+  font-weight: bold;
+}
+.nth-demo {
+  list-style: decimal inside;
+  padding: 0;
+  margin: 0.5em 0 0.5em 0;
+}
+.nth-demo li {
+  background: #f0e6fa;
+  margin-bottom: 0.3em;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+  transition: background 0.2s, color 0.2s;
+}
+.nth-demo li:nth-child(odd) {
+  background: #f0e6fa;
+}
+.nth-demo li:nth-child(2n) {
+  background: #e3f6fd;
+}
+.nth-demo li:nth-child(3) {
+  color: #f7971e;
+  font-weight: bold;
+}
+.empty-demo {
+  display: flex;
+  gap: 1em;
+  margin: 0.5em 0 0.5em 0;
+}
+.empty-box {
+  width: 100px;
+  height: 2em;
+  background: #e3f6fd;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1em;
+  color: #222;
+}
+.empty-box:empty {
+  border: 2px dashed #8e44ad;
+  background: #f0e6fa;
+}
+.not-demo {
+  display: flex;
+  gap: 1em;
+  list-style: none;
+  padding: 0;
+  margin: 0.5em 0 0.5em 0;
+}
+.not-demo li {
+  background: #e3f6fd;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+  color: #222;
+  font-weight: normal;
+  transition: background 0.2s, color 0.2s;
+}
+.not-demo li:not(.exclude) {
+  color: #3498db;
+  font-weight: bold;
+}
+.form-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7em;
+  margin: 0.5em 0 0.5em 0;
+  align-items: center;
+}
+.form-demo input[type="text"],
+.form-demo input[type="email"] {
+  padding: 0.5em 1em;
+  border: 2px solid #e3f6fd;
+  border-radius: 5px;
+  font-size: 1em;
+  transition: border-color 0.2s;
+}
+.form-demo input:required {
+  border-color: #f7971e;
+}
+.form-demo input:valid {
+  border-color: #3498db;
+}
+.form-demo input:invalid {
+  border-color: #e74c3c;
+}
+.form-demo input[type="checkbox"] {
+  accent-color: #8e44ad;
+  margin-right: 0.3em;
+}
+.form-demo input:checked + label {
+  color: #8e44ad;
+  font-weight: bold;
+}
+.form-demo button {
+  background: #8e44ad;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  padding: 0.5em 1.2em;
+  font-size: 1em;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.form-demo button:hover,
+.form-demo button:focus {
+  background: #3498db;
+}
+.back-btn {
+  display: inline-block;
+  margin-top: 2rem;
+  background: #ffd200;
+  color: #8e44ad;
+  padding: 0.7em 1.5em;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background 0.2s, color 0.2s;
+  box-shadow: 0 2px 8px rgba(52, 152, 219, 0.08);
+}
+.back-btn:hover,
+.back-btn:focus {
+  background: #8e44ad;
+  color: #fff;
+  outline: 2px solid #f7971e;
+  outline-offset: 2px;
+}
+@media (max-width: 600px) {
+  main {
+    padding: 1rem 0.5rem 2rem 0.5rem;
+  }
+  .page-header {
+    padding: 1.2rem 0.5rem 0.7rem 0.5rem;
+  }
+  .demo-block {
+    padding: 0.7rem 0.5rem;
+  }
+}

--- a/HTML/pseudo-class.html
+++ b/HTML/pseudo-class.html
@@ -65,9 +65,19 @@
           <li>Item 4</li>
           <li>Item 5</li>
         </ol>
+        <ul class="nth-of-type-demo">
+          <li>Apple</li>
+          <li>Banana</li>
+          <li>Cherry</li>
+          <li>Banana</li>
+          <li>Apple</li>
+        </ul>
         <pre><code>.nth-demo li:nth-child(odd) { background: #f0e6fa; }
 .nth-demo li:nth-child(3) { color: #f7971e; font-weight: bold; }
 .nth-demo li:nth-child(2n) { background: #e3f6fd; }
+
+.nth-of-type-demo li:nth-of-type(2) { background: #ffd200; color: #8e44ad; }
+.nth-of-type-demo li:nth-of-type(3) { background: #8e44ad; color: #fff; }
 </code></pre>
       </div>
       <div class="demo-block">
@@ -77,7 +87,7 @@
           <div class="empty-box"></div>
           <div class="empty-box">Not Empty</div>
         </div>
-        <pre><code>.empty-box:empty { border: 2px dashed #8e44ad; background: #f0e6fa; min-height: 2em; }</code></pre>
+        <pre><code>.empty-box:empty { border: 2px dashed #8e44ad; background: #f0e6fa;}</code></pre>
       </div>
       <div class="demo-block">
         <h3>:not()</h3>
@@ -114,7 +124,7 @@
         <li>Prefer semantic HTML for better selector targeting.</li>
       </ul>
     </section>
-    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+    <a href="../index.html" class="demo-btn back-btn">&larr; Back to Home</a>
   </main>
 </body>
 </html>

--- a/HTML/pseudo-class.html
+++ b/HTML/pseudo-class.html
@@ -1,0 +1,120 @@
+<!-- pseudo-class : hover, first-child, last-child,nth-child,first-of-type,last-of-type,nth-of-type,only-child,empty -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="In-depth guide to CSS pseudo-classes: theory, interactive examples, and best practices.">
+  <meta name="keywords" content="CSS, pseudo-class, hover, first-child, last-child, nth-child, only-child, empty, focus, active, web design, selectors, examples">
+  <meta name="author" content="Full Stack Mastery">
+  <link rel="icon" type="image/png" href="../images/css_favicon.png">
+  <link rel="stylesheet" href="../CSS/pseudo-class.css">
+  <title>CSS Pseudo-Classes: Theory & Interactive Examples</title>
+</head>
+<body>
+  <header class="page-header">
+    <h1>CSS Pseudo-Classes</h1>
+    <p class="subtitle">Deep Dive: Theory, Usage, and Interactive Demos</p>
+  </header>
+  <main>
+    <section class="theory-section">
+      <h2>What are CSS Pseudo-Classes?</h2>
+      <p><strong>Pseudo-classes</strong> are special keywords added to selectors that specify a special state of the selected elements. They allow you to style elements based on user interaction, position in the DOM, or other dynamic conditions, without adding extra classes or JavaScript.</p>
+      <ul>
+        <li><strong>User Interaction:</strong> <code>:hover</code>, <code>:focus</code>, <code>:active</code></li>
+        <li><strong>Structural:</strong> <code>:first-child</code>, <code>:last-child</code>, <code>:nth-child()</code>, <code>:only-child</code>, <code>:empty</code></li>
+        <li><strong>Form State:</strong> <code>:checked</code>, <code>:disabled</code>, <code>:required</code>, <code>:valid</code>, <code>:invalid</code></li>
+        <li><strong>Negation:</strong> <code>:not()</code></li>
+      </ul>
+      <p>Pseudo-classes are written after a selector, prefixed with a colon. Example: <code>a:hover</code> styles links when hovered.</p>
+    </section>
+    <section class="demo-section">
+      <h2>Interactive Examples</h2>
+      <div class="demo-block">
+        <h3>:hover, :focus, :active</h3>
+        <p>Style elements based on user interaction:</p>
+        <div class="button-demo">
+          <a href="#" class="demo-btn" tabindex="0">Hover, Focus, or Click Me</a>
+        </div>
+        <pre><code>.demo-btn:hover { background: #8e44ad; color: #fff; }
+.demo-btn:focus { outline: 2px solid #f7971e; }
+.demo-btn:active { background: #3498db; }</code></pre>
+      </div>
+      <div class="demo-block">
+        <h3>:first-child, :last-child, :only-child</h3>
+        <p>Target elements based on their position in the parent:</p>
+        <ul class="child-demo">
+          <li>First Child</li>
+          <li>Middle Child</li>
+          <li>Last Child</li>
+        </ul>
+        <ul class="child-demo single">
+          <li>Only Child</li>
+        </ul>
+        <pre><code>.child-demo li:first-child { color: #8e44ad; font-weight: bold; }
+.child-demo li:last-child { color: #3498db; }
+.child-demo.single li:only-child { background: #ffd200; }</code></pre>
+      </div>
+      <div class="demo-block">
+        <h3>:nth-child(), :nth-of-type()</h3>
+        <p>Style elements based on their index (1-based):</p>
+        <ol class="nth-demo">
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+          <li>Item 4</li>
+          <li>Item 5</li>
+        </ol>
+        <pre><code>.nth-demo li:nth-child(odd) { background: #f0e6fa; }
+.nth-demo li:nth-child(3) { color: #f7971e; font-weight: bold; }
+.nth-demo li:nth-child(2n) { background: #e3f6fd; }
+</code></pre>
+      </div>
+      <div class="demo-block">
+        <h3>:empty</h3>
+        <p>Target elements with no children (including text):</p>
+        <div class="empty-demo">
+          <div class="empty-box"></div>
+          <div class="empty-box">Not Empty</div>
+        </div>
+        <pre><code>.empty-box:empty { border: 2px dashed #8e44ad; background: #f0e6fa; min-height: 2em; }</code></pre>
+      </div>
+      <div class="demo-block">
+        <h3>:not()</h3>
+        <p>Exclude elements from a selection:</p>
+        <ul class="not-demo">
+          <li>Apple</li>
+          <li class="exclude">Banana</li>
+          <li>Cherry</li>
+        </ul>
+        <pre><code>.not-demo li:not(.exclude) { color: #3498db; font-weight: bold; }</code></pre>
+      </div>
+      <div class="demo-block">
+        <h3>Form State Pseudo-Classes</h3>
+        <form class="form-demo" autocomplete="off">
+          <input type="text" placeholder="Required" required>
+          <input type="email" placeholder="Email" required>
+          <input type="checkbox" id="check" required>
+          <label for="check">Check me</label>
+          <button type="submit">Submit</button>
+        </form>
+        <pre><code>.form-demo input:required { border-color: #f7971e; }
+.form-demo input:valid { border-color: #3498db; }
+.form-demo input:invalid { border-color: #e74c3c; }
+.form-demo input:checked + label { color: #8e44ad; font-weight: bold; }</code></pre>
+      </div>
+    </section>
+    <section class="best-practices">
+      <h2>Best Practices & Accessibility</h2>
+      <ul>
+        <li>Use <code>:focus</code> styles for keyboard accessibility.</li>
+        <li>Combine pseudo-classes for advanced effects (e.g., <code>a:hover:active</code>).</li>
+        <li>Test pseudo-class behavior across browsers and devices.</li>
+        <li>Use <code>:not()</code> to simplify complex selectors.</li>
+        <li>Prefer semantic HTML for better selector targeting.</li>
+      </ul>
+    </section>
+    <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+  </main>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -929,19 +929,19 @@ See **psuedo-elements.html** for interactive demos:
 
 ## 22. CSS Pseudo-Classes
 
-CSS <strong>pseudo-classes</strong> are special selectors that target elements in a specific state, such as when a user hovers over a link, when an input is focused, or when an element is the first child of its parent. Pseudo-classes enable dynamic, interactive, and context-aware styling without extra classes or JavaScript.
+CSS **pseudo-classes** are special selectors that target elements in a specific state, such as when a user hovers over a link, when an input is focused, or when an element is the first child of its parent. Pseudo-classes enable dynamic, interactive, and context-aware styling without extra classes or JavaScript.
 
 ### Common Pseudo-Classes
-- <code>:hover</code> – Styles elements when hovered by a pointer.
-- <code>:focus</code> – Styles elements when focused (e.g., via keyboard/tab).
-- <code>:active</code> – Styles elements when activated (e.g., clicked).
-- <code>:first-child</code> – Targets the first child of a parent.
-- <code>:last-child</code> – Targets the last child of a parent.
-- <code>:nth-child(n)</code> – Targets the nth child (e.g., <code>:nth-child(2n)</code> for even items).
-- <code>:only-child</code> – Targets an element that is the only child of its parent.
-- <code>:empty</code> – Targets elements with no children (including text).
-- <code>:not(selector)</code> – Excludes elements matching a selector.
-- <code>:checked</code>, <code>:disabled</code>, <code>:required</code>, <code>:valid</code>, <code>:invalid</code> – Target form states.
+- `:hover` – Styles elements when hovered by a pointer.
+- `:focus` – Styles elements when focused (e.g., via keyboard/tab).
+- `:active` – Styles elements when activated (e.g., clicked).
+- `:first-child` – Targets the first child of a parent.
+- `:last-child` – Targets the last child of a parent.
+- `:nth-child(n)` – Targets the nth child (e.g., `:nth-child(2n)` for even items).
+- `:only-child` – Targets an element that is the only child of its parent.
+- `:empty` – Targets elements with no children (including text).
+- `:not(selector)` – Excludes elements matching a selector.
+- `:checked`, `:disabled`, `:required`, `:valid`, `:invalid` – Target form states.
 
 ### Example Usage
 ```css

--- a/Summary.md
+++ b/Summary.md
@@ -927,4 +927,49 @@ See **psuedo-elements.html** for interactive demos:
 
 ---
 
+## 22. CSS Pseudo-Classes
+
+CSS <strong>pseudo-classes</strong> are special selectors that target elements in a specific state, such as when a user hovers over a link, when an input is focused, or when an element is the first child of its parent. Pseudo-classes enable dynamic, interactive, and context-aware styling without extra classes or JavaScript.
+
+### Common Pseudo-Classes
+- <code>:hover</code> – Styles elements when hovered by a pointer.
+- <code>:focus</code> – Styles elements when focused (e.g., via keyboard/tab).
+- <code>:active</code> – Styles elements when activated (e.g., clicked).
+- <code>:first-child</code> – Targets the first child of a parent.
+- <code>:last-child</code> – Targets the last child of a parent.
+- <code>:nth-child(n)</code> – Targets the nth child (e.g., <code>:nth-child(2n)</code> for even items).
+- <code>:only-child</code> – Targets an element that is the only child of its parent.
+- <code>:empty</code> – Targets elements with no children (including text).
+- <code>:not(selector)</code> – Excludes elements matching a selector.
+- <code>:checked</code>, <code>:disabled</code>, <code>:required</code>, <code>:valid</code>, <code>:invalid</code> – Target form states.
+
+### Example Usage
+```css
+/* Highlight a button on hover and focus */
+.button:hover, .button:focus {
+  background: #8e44ad;
+  color: #fff;
+}
+/* Style the first and last list items */
+ul li:first-child { color: #8e44ad; }
+ul li:last-child { color: #3498db; }
+/* Alternate row colors */
+table tr:nth-child(even) { background: #f0e6fa; }
+/* Only child styling */
+.card:only-child { border: 2px solid #ffd200; }
+/* Exclude certain items */
+.menu li:not(.active) { opacity: 0.7; }
+```
+
+### Best Practices
+- Always provide <code>:focus</code> styles for accessibility.
+- Combine pseudo-classes for advanced effects (e.g., <code>a:hover:active</code>).
+- Use <code>:not()</code> to simplify complex selectors.
+- Test pseudo-class behavior across browsers and devices.
+
+### Reference Example
+See <a href="HTML/pseudo-class.html">pseudo-class.html</a> for a comprehensive, interactive demo and code examples of all major CSS pseudo-classes in action.
+
+---
+
 _Keep updating this summary as you explore more advanced CSS concepts like animations, transitions, Flexbox, Grid, media queries, and preprocessors (like SASS)._ 🚀

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         <li><a href="HTML/z-index.html">CSS Z-index</a></li>
         <li><a href="HTML/overflow.html">CSS Overflow</a></li>
         <li><a href="HTML/psuedo-elements.html">CSS Pseudo-elements</a></li>
+        <li><a href="HTML/pseudo-class.html">CSS Pseudo-classes</a></li>
     </ul>
 
     <div class="section-divider"></div>


### PR DESCRIPTION
Add comprehensive documentation for CSS pseudo-classes in Summary.md, including:
- Explanation of common pseudo-classes
- Example usage patterns
- Best practices for accessibility and cross-browser compatibility

Create new pseudo-class.html and pseudo-class.css files with interactive demos showcasing:
- User interaction states (:hover, :focus, :active)
- Structural selectors (:first-child, :nth-child, etc)
- Form state selectors (:checked, :valid, etc)
- Negation selector (:not)

Update index.html to include link to new pseudo-classes page