### PR TITLE
feat: add all-property documentation page with interactive examples

### DIFF
--- a/CSS/all-property.css
+++ b/CSS/all-property.css
@@ -1,0 +1,278 @@
+:root {
+    --color-bg-main: #f7f9fb;
+    --color-bg-section: #f0f4fa;
+    --color-bg-card: #f8fafc;
+    --color-bg-btn: #e3e9f7;
+    --color-bg-btn-hover: #d0d8ee;
+    --color-text-main: #222;
+    --color-text-accent: #4f8cff;
+    --color-text-secondary: #2a4d8f;
+    --color-border: #b3c6e0;
+    --color-tip-bg: #fef9c3;
+    --color-tip-border: #fde047;
+    --color-tip-text: #b8860b;
+    --color-note-bg: #e0f2fe;
+    --color-note-text: #217dbb;
+
+    --font-main: 'Segoe UI', Arial, sans-serif;
+    --font-size-base: 1rem;
+    --font-size-h1: 2.2rem;
+    --font-size-h2: 1.4rem;
+    --font-size-h3: 1.1rem;
+    --font-size-code: 0.98rem;
+    --font-weight-bold: 700;
+    --font-weight-semi: 600;
+
+    --space-xs: 0.5rem;
+    --space-sm: 0.8rem;
+    --space-md: 1.2rem;
+    --space-lg: 2rem;
+    --space-xl: 2.5rem;
+
+    --radius-card: 0.8rem;
+    --radius-btn: 0.4rem;
+
+    --shadow-1: 0 0.0625rem 0.25rem #0001;
+    --shadow-2: 0 0.0625rem 0.5rem #0001;
+    --shadow-3: 0 0.125rem 0.5rem #0002;
+    --shadow-4: 0 0.25rem 1rem #4f8cff33;
+    --shadow-5: 0 0.25rem 2rem #0002;
+}
+
+body {
+    font-family: var(--font-main);
+    background: var(--color-bg-main);
+    color: var(--color-text-main);
+    margin: 0;
+    padding: 0;
+    font-size: var(--font-size-base);
+}
+
+.back-nav {
+    margin-top: var(--space-lg);
+    margin-left: var(--space-lg);
+}
+.back-btn {
+    display: inline-block;
+    background: var(--color-bg-btn);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-btn);
+    font-weight: var(--font-weight-semi);
+    transition: background-color 0.2s;
+    box-shadow: var(--shadow-1);
+}
+.back-btn:hover {
+    background: var(--color-bg-btn-hover);
+}
+
+.all-main {
+    max-width: 56rem;
+    margin: var(--space-xl) auto;
+    background: var(--color-bg-card);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-5);
+    padding: var(--space-xl) var(--space-lg) var(--space-lg) var(--space-lg);
+}
+
+.all-header {
+    text-align: center;
+    margin-bottom: var(--space-xl);
+}
+.all-header h1 {
+    font-size: var(--font-size-h1);
+    font-weight: var(--font-weight-bold);
+    margin: 0.2rem 0 0.1rem 0;
+}
+.all-header .highlight {
+    color: var(--color-text-accent);
+}
+.subtitle {
+    color: var(--color-text-accent);
+    font-size: var(--font-size-h3);
+    margin-bottom: var(--space-xs);
+}
+
+.theory-section {
+    background: var(--color-bg-section);
+    border-radius: var(--radius-card);
+    padding: var(--space-lg) var(--space-lg) var(--space-md) var(--space-lg);
+    margin-bottom: var(--space-xl);
+    box-shadow: var(--shadow-2);
+}
+.theory-section h2 {
+    margin-top: 0;
+    color: var(--color-text-secondary);
+}
+.theory-list {
+    margin: 1rem 0 1rem 1.5rem;
+    padding: 0;
+    list-style: disc inside;
+}
+.theory-list li {
+    margin-bottom: var(--space-xs);
+    font-size: 1.05rem;
+}
+.syntax-block {
+    background: var(--color-bg-main);
+    border-left: 0.25rem solid var(--color-text-accent);
+    padding: 1rem 1.5rem;
+    border-radius: var(--radius-btn);
+    margin-bottom: var(--space-md);
+}
+.tip-block {
+    display: flex;
+    align-items: center;
+    background: var(--color-tip-bg);
+    border-left: 0.25rem solid var(--color-tip-border);
+    padding: 0.7rem 1.2rem;
+    border-radius: var(--radius-btn);
+    margin-bottom: var(--space-md);
+    font-size: 1.04rem;
+    color: var(--color-tip-text);
+}
+.tip-icon {
+    font-size: 1.3rem;
+    margin-right: 0.5rem;
+}
+
+.examples-section {
+    margin-bottom: var(--space-xl);
+}
+.example-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+}
+.example-card {
+    background: var(--color-bg-section);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-2);
+    padding: var(--space-md) var(--space-md) 1.2rem var(--space-md);
+    flex: 1 1 15rem;
+    min-width: 13rem;
+    max-width: 22rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+.example-card:hover {
+    box-shadow: var(--shadow-4);
+    transform: translateY(-0.18rem) scale(1.03);
+}
+.reset-btn {
+    background: var(--color-text-accent);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-btn);
+    padding: 0.7rem 1.5rem;
+    font-size: 1.1rem;
+    cursor: pointer;
+    margin-right: 0.7rem;
+    margin-bottom: var(--space-xs);
+    transition: background 0.2s;
+}
+.reset-btn:hover,
+.reset-btn:focus {
+    background: var(--color-text-secondary);
+}
+.all-unset {
+    all: unset;
+    background: #ffe4e6;
+    color: #be185d;
+    border-radius: var(--radius-btn);
+    padding: 0.7rem 1.5rem;
+    font-size: 1.1rem;
+    cursor: pointer;
+    border: 2px dashed #be185d;
+    margin-right: 0.7rem;
+    margin-bottom: var(--space-xs);
+    transition: background 0.2s;
+}
+.inherit-demo-parent {
+    color: #7c3aed;
+    font-size: 1.3rem;
+    font-weight: bold;
+    margin-bottom: var(--space-xs);
+}
+.inherit-demo-child {
+    color: #222;
+    font-size: 1rem;
+    font-weight: normal;
+    margin-right: 1.2rem;
+}
+.all-inherit {
+    all: inherit;
+}
+.revert-demo {
+    color: #be185d;
+    font-size: 1.2rem;
+    font-style: italic;
+    margin-bottom: var(--space-xs);
+}
+.revert-child {
+    color: #4f8cff;
+    font-size: 1.5rem;
+    font-style: normal;
+    margin-right: 1.2rem;
+}
+.all-revert {
+    all: revert;
+}
+.code-block {
+    background: var(--color-bg-main);
+    color: var(--color-text-secondary);
+    font-family: monospace;
+    font-size: var(--font-size-code);
+    border-radius: var(--radius-btn);
+    padding: var(--space-xs) var(--space-md);
+    margin-top: var(--space-xs);
+    width: 100%;
+    overflow-x: auto;
+    box-shadow: var(--shadow-1);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+.code-block:active, .code-block:focus {
+    background: var(--color-bg-btn-hover);
+}
+.note {
+    background: var(--color-note-bg);
+    color: var(--color-note-text);
+    border-left: 0.25rem solid var(--color-text-accent);
+    padding: 0.7rem 1.2rem;
+    border-radius: var(--radius-btn);
+    margin-top: 1.2rem;
+    font-size: 1.02rem;
+}
+.references-section {
+    margin-top: var(--space-xl);
+    padding-top: var(--space-md);
+    border-top: 0.0625rem solid var(--color-border);
+}
+.references-section h2 {
+    color: var(--color-text-secondary);
+}
+.references-section ul {
+    margin: 0.5rem 0 0 1.2rem;
+}
+.references-section a {
+    color: var(--color-text-accent);
+    text-decoration: underline;
+    transition: color 0.2s;
+}
+.references-section a:hover {
+    color: var(--color-text-secondary);
+}
+@media (max-width: 56rem) {
+    .all-main {
+        padding: var(--space-lg) var(--space-md);
+    }
+    .example-grid {
+        flex-direction: column;
+        gap: var(--space-md);
+    }
+}

--- a/HTML/all-property.html
+++ b/HTML/all-property.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="In-depth guide to the CSS all property with interactive examples and best practices.">
+    <meta name="keywords" content="css, all property, css all, css reset, css demo">
+    <meta name="author" content="Suraj Ingole">
+    <meta name="robots" content="index, follow">
+    <link rel="shortcut icon" href="../images/css_favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../CSS/all-property.css">
+    <title>CSS all Property – Theory & Interactive Examples</title>
+</head>
+<body>
+    <nav class="back-nav">
+        <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+    </nav>
+    <main class="all-main">
+        <header class="all-header">
+            <h1><span class="highlight">CSS <code>all</code> Property</span></h1>
+            <p class="subtitle">Reset or inherit all CSS properties in a single declaration!</p>
+        </header>
+        <section class="theory-section">
+            <h2>What is the <code>all</code> Property?</h2>
+            <p>
+                The <strong>CSS <code>all</code> property</strong> is a powerful shorthand that lets you reset or inherit <em>all</em> CSS properties (except <code>unicode-bidi</code> and <code>direction</code>) at once. It's especially useful for resetting styles in components, modals, or third-party widgets.
+            </p>
+            <ul class="theory-list">
+                <li>
+                    <strong>Reset Everything:</strong> Use <code>all: unset;</code> to remove all inherited and user-agent styles from an element.
+                </li>
+                <li>
+                    <strong>Inherit Everything:</strong> Use <code>all: inherit;</code> to make an element inherit all properties from its parent.
+                </li>
+                <li>
+                    <strong>Revert Everything:</strong> Use <code>all: revert;</code> to revert all properties to their default UA or user styles.
+                </li>
+                <li>
+                    <strong>Not for Animatable Properties:</strong> <code>all</code> cannot be transitioned or animated.
+                </li>
+            </ul>
+            <div class="syntax-block">
+                <h3>Syntax</h3>
+                <pre><code>selector {
+  all: unset | initial | inherit | revert | revert-layer;
+}
+                </code></pre>
+            </div>
+            <div class="tip-block">
+                <span class="tip-icon">💡</span>
+                <span>
+                    <strong>Tip:</strong> <code>all: unset;</code> is great for creating "unstyled" buttons or links that ignore all browser and inherited styles!
+                </span>
+            </div>
+            <div class="note">
+                <strong>Browser Support:</strong> The <code>all</code> property is supported in all modern browsers.
+            </div>
+        </section>
+
+        <section class="examples-section">
+            <h2>Interactive Examples</h2>
+            <div class="example-grid">
+                <!-- Example 1: Reset Button -->
+                <div class="example-card">
+                    <h3>Reset Button Styles</h3>
+                    <button class="reset-btn">Normal Button</button>
+                    <button class="reset-btn all-unset">All: Unset</button>
+                    <pre class="code-block" tabindex="0">
+.reset-btn {
+  background: #4f8cff;
+  color: #fff;
+  border: none;
+  border-radius: 0.4rem;
+  padding: 0.7rem 1.5rem;
+  font-size: 1.1rem;
+  cursor: pointer;
+  margin-right: 0.7rem;
+}
+.all-unset {
+  all: unset;
+  background: #ffe4e6;
+  color: #be185d;
+  border-radius: 0.4rem;
+  padding: 0.7rem 1.5rem;
+  font-size: 1.1rem;
+  cursor: pointer;
+  border: 2px dashed #be185d;
+}
+                    </pre>
+                </div>
+                <!-- Example 2: Inherit All Properties -->
+                <div class="example-card">
+                    <h3>Inherit All Properties</h3>
+                    <div class="inherit-demo-parent">
+                        <span class="inherit-demo-child">Default Child</span>
+                        <span class="inherit-demo-child all-inherit">All: Inherit</span>
+                    </div>
+                    <pre class="code-block" tabindex="0">
+.inherit-demo-parent {
+  color: #7c3aed;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+.inherit-demo-child {
+  color: #222;
+  font-size: 1rem;
+  font-weight: normal;
+  margin-right: 1.2rem;
+}
+.all-inherit {
+  all: inherit;
+}
+                    </pre>
+                </div>
+                <!-- Example 3: Revert All Properties -->
+                <div class="example-card">
+                    <h3>Revert All Properties</h3>
+                    <div class="revert-demo">
+                        <span class="revert-child">Styled Child</span>
+                        <span class="revert-child all-revert">All: Revert</span>
+                    </div>
+                    <pre class="code-block" tabindex="0">
+.revert-demo {
+  color: #be185d;
+  font-size: 1.2rem;
+  font-style: italic;
+}
+.revert-child {
+  color: #4f8cff;
+  font-size: 1.5rem;
+  font-style: normal;
+  margin-right: 1.2rem;
+}
+.all-revert {
+  all: revert;
+}
+                    </pre>
+                </div>
+            </div>
+            <div class="note">
+                <strong>Try it:</strong> Compare the buttons and text above to see how <code>all</code> can reset, inherit, or revert all CSS properties at once!
+            </div>
+        </section>
+
+        <section class="references-section">
+            <h2>References</h2>
+            <ul>
+                <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/all" target="_blank" rel="noopener">MDN: CSS all property</a></li>
+                <li><a href="https://css-tricks.com/almanac/properties/a/all/" target="_blank" rel="noopener">CSS-Tricks: all property</a></li>
+            </ul>
+        </section>
+    </main>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -54,7 +54,8 @@ Whether you're a beginner or an experienced developer, use this summary to quick
 - [CSS Scroll Snap](#41-css-scroll-snap)
 - [CSS Reduced Motion Query](#42-css-prefers-reduced-motion-media-query)
 - [CSS Nesting](#43-css-nesting)
-- [CSS @Layer]()
+- [CSS @Layer](#44-css-layer-cascade-layers)
+- [CSS All Property](#45-css-all-property)
 ---
 
 ## 1. What is CSS?
@@ -3001,3 +3002,142 @@ p {
 -   Web.dev: [Cascade Layers](https://web.dev/css-cascade-layers/)
 -   CSS-Tricks: [A Complete Guide To CSS Cascade Layers](https://css-tricks.com/a-complete-guide-to-css-cascade-layers/)
 -   Miriam Suzanne's Explainer: [The Future of CSS: Cascade Layers (CSS @layer)](https://www.miriamsuzanne.com/blog/2021/05/20/cascade-layers/)
+
+
+## 45. CSS `all` Property
+
+### What is the `all` Property in CSS?
+
+The `all` CSS shorthand property is a powerful and concise way to **reset all CSS properties of an element (except for `direction` and `unicode-bidi`) to their initial, inherited, or unset states**. It's particularly useful for creating isolated components, ensuring that a component's styling isn't unintentionally affected by global styles or inherited properties from its parent elements.
+
+It acts as a "reset button" for an element's styling, allowing you to establish a clean slate for its contained content.
+
+#### Example:
+
+Imagine you have a reusable `Modal` component, and you want to ensure its styling is completely self-contained and not influenced by any external CSS that might accidentally bleed into it.
+
+HTML
+
+```html
+<div class="modal-backdrop">
+  <div class="modal-content">
+    <h1>Modal Title</h1>
+    <p>Some modal content here.</p>
+    <button>Close</button>
+  </div>
+</div>
+
+```
+
+CSS
+
+```css
+/* CSS */
+/* Global styles that might accidentally affect a modal */
+body {
+  font-family: Georgia, serif;
+  font-size: 18px;
+  color: #333;
+}
+
+h1 {
+  margin-top: 2em;
+  color: purple;
+}
+
+/* Using 'all' to reset the modal content */
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  max-width: 500px;
+  text-align: center;
+
+  /* The magic happens here: */
+  all: unset; /* Resets all properties to their unset (initial or inherited) state */
+
+  /* Now re-apply only the desired properties */
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  max-width: 500px;
+  text-align: center;
+
+  /* Explicitly re-set properties that would normally inherit */
+  font-family: sans-serif;
+  font-size: 16px;
+  color: #000;
+  line-height: 1.5;
+}
+
+/* Any nested elements inside modal-content will now inherit from modal-content's *new* reset values,
+   not from the body or other external styles. */
+.modal-content h1 {
+  margin-top: 0; /* Ensures no inherited margin-top from global h1 */
+  color: #222;
+  font-size: 1.8em;
+}
+
+```
+
+### `all` Property Values:
+
+The `all` property can take one of four global keyword values:
+
+-   **`initial`:** Resets all properties (except `direction` and `unicode-bidi`) to their **initial (default) values** as defined by the CSS specification for that property. For properties that are not inherited, this is effectively a complete reset.
+    
+    -   Example: `color` would become `black`, `background-color` would become `transparent`, `display` would become `inline`.
+        
+-   **`inherit`:** Resets all properties to their **computed inherited values** from the parent element. If a property is not normally inheritable, it will be reset to its `initial` value.
+    
+    -   Example: `color` would inherit the parent's color, `border` would become `none` (as it's not inherited), `font-size` would inherit.
+        
+-   **`unset`:** This is often the most practical and commonly used value for `all`.
+    
+    -   For **inherited properties**, it behaves like `inherit`.
+        
+    -   For **non-inherited properties**, it behaves like `initial`.
+        
+    -   This makes it a "smart" reset: properties that are naturally inherited will continue to be, while those that aren't will go back to their defaults.
+        
+-   **`revert`:** Resets all properties to the values established by the **previous cascade origin**. This means it reverts to the user-agent stylesheet's value if the author stylesheet defines it, or to the user stylesheet's value if it's present. It's particularly useful when dealing with custom user stylesheets or browser defaults.
+    
+-   **`revert-layer`:** Similar to `revert`, but specifically for **Cascade Layers**. It reverts the property to the value established in the previous cascade layer. This is useful when you want to undo an override made in the current layer and let an earlier layer's style take effect.
+    
+
+### 🔑 Key Points:
+
+-   **Global Reset:** Resets _all_ CSS properties on an element, except `direction` and `unicode-bidi`.
+    
+-   **Isolation:** Excellent for creating isolated UI components or shadow DOM content where you want to prevent external styles from affecting internal elements.
+    
+-   **Cleanup:** Can be used to "clean up" an element's styles before applying a completely new set of rules.
+    
+-   **Understanding Values:** Choose `initial`, `inherit`, `unset`, `revert`, or `revert-layer` carefully based on whether you want a hard reset, inherited values, or a reversion to a previous cascade state. `unset` is generally the most common and versatile choice for component isolation.
+    
+
+### Best Practices
+
+-   **Use sparingly and strategically:** `all` is very powerful and can easily strip away expected browser defaults or inherited styles. It's best used in scenarios where you genuinely need a complete style reset for a specific component.
+    
+-   **Apply and re-apply:** When using `all`, you'll typically follow it immediately with specific property declarations to set the desired styles for the element, as `all` wipes everything away.
+    
+-   **Combine with `:where()` or `:is()`:** For more specific use cases, you might combine `all` with selector functions to apply it to a range of elements without being too broad.
+    
+-   **Consider its impact on accessibility:** Ensure that resetting all styles doesn't inadvertently remove crucial styling that aids accessibility (e.g., focus outlines).
+    
+
+### Compatibility
+
+-   Widely supported in all modern browsers (Chrome, Edge, Firefox, Safari).
+-  `revert-layer` has slightly newer support, usually tied to Cascade Layers support.
+-   No support in Internet Explorer.
+    
+
+### Further Reading
+
+-   MDN: [`all`](https://developer.mozilla.org/en-US/docs/Web/CSS/all)
+-   CSS-Tricks: [The `all` Property](https://css-tricks.com/almanac/properties/a/all/)
+-   Web.dev: [The CSS `all` property](https://web.dev/css-all-property/)

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
           <li><a href="HTML/reduced-motion-query.html" target="_blank" rel="noopener noreferrer">CSS Reduced Motion Query</a></li>
           <li><a href="HTML/css-nesting.html" target="_blank" rel="noopener noreferrer">CSS Nesting</a></li>
           <li><a href="HTML/css-@layer.html" target="_blank" rel="noopener noreferrer">CSS @layer</a></li>
+          <li><a href="HTML/all-property.html" target="_blank" rel="noopener noreferrer">CSS All Property</a></li>
         </ul>
       </section>
       <div class="section-divider"></div>


### PR DESCRIPTION
Add comprehensive HTML and CSS files for the CSS `all` property documentation page. Includes theory section explaining the property's purpose and values, interactive examples demonstrating `unset`, `inherit`, and `revert` behaviors, and references to MDN and CSS-Tricks. Also updates Summary.md to include the new section.