### PR TITLE
feat: add accent-color property documentation and examples

### DIFF
--- a/CSS/accent-color.css
+++ b/CSS/accent-color.css
@@ -1,0 +1,233 @@
+:root {
+    --color-bg-main: #f7f9fb;
+    --color-bg-section: #f0f4fa;
+    --color-bg-card: #f8fafc;
+    --color-bg-btn: #e3e9f7;
+    --color-bg-btn-hover: #d0d8ee;
+    --color-text-main: #222;
+    --color-text-accent: #4f8cff;
+    --color-text-secondary: #2a4d8f;
+    --color-border: #b3c6e0;
+    --color-tip-bg: #fef9c3;
+    --color-tip-border: #fde047;
+    --color-tip-text: #b8860b;
+    --color-note-bg: #e0f2fe;
+    --color-note-text: #217dbb;
+    --color-accent: #4f8cff;
+
+    --font-main: 'Segoe UI', Arial, sans-serif;
+    --font-size-base: 1rem;
+    --font-size-h1: 2.2rem;
+    --font-size-h2: 1.4rem;
+    --font-size-h3: 1.1rem;
+    --font-size-code: 0.98rem;
+    --font-weight-bold: 700;
+    --font-weight-semi: 600;
+
+    --space-xs: 0.5rem;
+    --space-sm: 0.8rem;
+    --space-md: 1.2rem;
+    --space-lg: 2rem;
+    --space-xl: 2.5rem;
+
+    --radius-card: 0.8rem;
+    --radius-btn: 0.4rem;
+
+    --shadow-1: 0 0.0625rem 0.25rem #0001;
+    --shadow-2: 0 0.0625rem 0.5rem #0001;
+    --shadow-3: 0 0.125rem 0.5rem #0002;
+    --shadow-4: 0 0.25rem 1rem #4f8cff33;
+    --shadow-5: 0 0.25rem 2rem #0002;
+}
+
+body {
+    font-family: var(--font-main);
+    background: var(--color-bg-main);
+    color: var(--color-text-main);
+    margin: 0;
+    padding: 0;
+    font-size: var(--font-size-base);
+}
+
+.back-nav {
+    margin-top: var(--space-lg);
+    margin-left: var(--space-lg);
+}
+.back-btn {
+    display: inline-block;
+    background: var(--color-bg-btn);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-btn);
+    font-weight: var(--font-weight-semi);
+    transition: background-color 0.2s;
+    box-shadow: var(--shadow-1);
+}
+.back-btn:hover {
+    background: var(--color-bg-btn-hover);
+}
+
+.accent-main {
+    max-width: 56rem;
+    margin: var(--space-xl) auto;
+    background: var(--color-bg-card);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-5);
+    padding: var(--space-xl) var(--space-lg) var(--space-lg) var(--space-lg);
+}
+
+.accent-header {
+    text-align: center;
+    margin-bottom: var(--space-xl);
+}
+.accent-header h1 {
+    font-size: var(--font-size-h1);
+    font-weight: var(--font-weight-bold);
+    margin: 0.2rem 0 0.1rem 0;
+}
+.accent-header .highlight {
+    color: var(--color-text-accent);
+}
+.subtitle {
+    color: var(--color-text-accent);
+    font-size: var(--font-size-h3);
+    margin-bottom: var(--space-xs);
+}
+
+.theory-section {
+    background: var(--color-bg-section);
+    border-radius: var(--radius-card);
+    padding: var(--space-lg) var(--space-lg) var(--space-md) var(--space-lg);
+    margin-bottom: var(--space-xl);
+    box-shadow: var(--shadow-2);
+}
+.theory-section h2 {
+    margin-top: 0;
+    color: var(--color-text-secondary);
+}
+.theory-list {
+    margin: 1rem 0 1rem 1.5rem;
+    padding: 0;
+    list-style: disc inside;
+}
+.theory-list li {
+    margin-bottom: var(--space-xs);
+    font-size: 1.05rem;
+}
+.syntax-block {
+    background: var(--color-bg-main);
+    border-left: 0.25rem solid var(--color-text-accent);
+    padding: 1rem 1.5rem;
+    border-radius: var(--radius-btn);
+    margin-bottom: var(--space-md);
+}
+.tip-block {
+    display: flex;
+    align-items: center;
+    background: var(--color-tip-bg);
+    border-left: 0.25rem solid var(--color-tip-border);
+    padding: 0.7rem 1.2rem;
+    border-radius: var(--radius-btn);
+    margin-bottom: var(--space-md);
+    font-size: 1.04rem;
+    color: var(--color-tip-text);
+}
+.tip-icon {
+    font-size: 1.3rem;
+    margin-right: 0.5rem;
+}
+
+.examples-section {
+    margin-bottom: var(--space-xl);
+}
+.example-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+}
+.example-card {
+    background: var(--color-bg-section);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-2);
+    padding: var(--space-md) var(--space-md) 1.2rem var(--space-md);
+    flex: 1 1 15rem;
+    min-width: 13rem;
+    max-width: 22rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+.example-card:hover {
+    box-shadow: var(--shadow-4);
+    transform: translateY(-0.18rem) scale(1.03);
+}
+.code-block {
+    background: var(--color-bg-main);
+    color: var(--color-text-secondary);
+    font-family: monospace;
+    font-size: var(--font-size-code);
+    border-radius: var(--radius-btn);
+    padding: var(--space-xs) var(--space-md);
+    margin-top: var(--space-xs);
+    width: 100%;
+    overflow-x: auto;
+    box-shadow: var(--shadow-1);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+.code-block:active, .code-block:focus {
+    background: var(--color-bg-btn-hover);
+}
+.note {
+    background: var(--color-note-bg);
+    color: var(--color-note-text);
+    border-left: 0.25rem solid var(--color-text-accent);
+    padding: 0.7rem 1.2rem;
+    border-radius: var(--radius-btn);
+    margin-top: 1.2rem;
+    font-size: 1.02rem;
+}
+.references-section {
+    margin-top: var(--space-xl);
+    padding-top: var(--space-md);
+    border-top: 0.0625rem solid var(--color-border);
+}
+.references-section h2 {
+    color: var(--color-text-secondary);
+}
+.references-section ul {
+    margin: 0.5rem 0 0 1.2rem;
+}
+.references-section a {
+    color: var(--color-text-accent);
+    text-decoration: underline;
+    transition: color 0.2s;
+}
+.references-section a:hover {
+    color: var(--color-text-secondary);
+}
+
+/* Accent color demo controls */
+.accent-demo {
+    accent-color: var(--color-accent, #4f8cff);
+    margin-right: 1.1rem;
+    margin-bottom: 0.7rem;
+    vertical-align: middle;
+}
+progress.accent-demo {
+    width: 8rem;
+    height: 1.2rem;
+    margin-top: 0.7rem;
+    margin-bottom: 0.7rem;
+    display: block;
+}
+@media (max-width: 56rem) {
+    .accent-main {
+        padding: var(--space-lg) var(--space-md);
+    }
+    .example-grid {
+        flex-direction: column;
+        gap: var(--

--- a/CSS/accent-color.css
+++ b/CSS/accent-color.css
@@ -230,4 +230,6 @@ progress.accent-demo {
     }
     .example-grid {
         flex-direction: column;
-        gap: var(--
+        gap: var(--space-md);
+    }
+}

--- a/HTML/accent-color.html
+++ b/HTML/accent-color.html
@@ -1,107 +1,167 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="In-depth guide to the CSS accent-color property with interactive examples and best practices.">
-    <meta name="keywords" content="css, accent-color, form controls, css accent, css demo">
-    <meta name="author" content="Suraj Ingole">
-    <meta name="robots" content="index, follow">
-    <link rel="shortcut icon" href="../images/css_favicon.png" type="image/x-icon">
-    <link rel="stylesheet" href="../CSS/accent-color.css">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="In-depth guide to the CSS accent-color property with interactive examples and best practices."
+    />
+    <meta
+      name="keywords"
+      content="css, accent-color, form controls, css accent, css demo"
+    />
+    <meta name="author" content="Suraj Ingole" />
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="shortcut icon"
+      href="../images/css_favicon.png"
+      type="image/x-icon"
+    />
+    <link rel="stylesheet" href="../CSS/accent-color.css" />
     <title>CSS accent-color – Theory & Interactive Examples</title>
-</head>
-<body>
+  </head>
+  <body>
     <nav class="back-nav">
-        <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+      <a href="../index.html" class="back-btn">&larr; Back to Home</a>
     </nav>
     <main class="accent-main">
-        <header class="accent-header">
-            <h1><span class="highlight">CSS <code>accent-color</code></span></h1>
-            <p class="subtitle">Easily customize the color of native form controls for a modern, branded UI!</p>
-        </header>
-        <section class="theory-section">
-            <h2>What is the <code>accent-color</code> Property?</h2>
-            <p>
-                The <strong>CSS <code>accent-color</code> property</strong> allows you to set the accent color for form controls such as checkboxes, radio buttons, range sliders, and progress bars. This makes it easy to match native controls to your site's color scheme without complex custom markup or JavaScript.
-            </p>
-            <ul class="theory-list">
-                <li>
-                    <strong>Simple Customization:</strong> Change the accent color of supported controls with a single line of CSS.
-                </li>
-                <li>
-                    <strong>Native Look & Feel:</strong> Controls remain accessible and keep their native behavior.
-                </li>
-                <li>
-                    <strong>Wide Support:</strong> Works in all modern browsers for checkboxes, radios, range, and progress.
-                </li>
-            </ul>
-            <div class="syntax-block">
-                <h3>Syntax</h3>
-                <pre><code>selector {
+      <header class="accent-header">
+        <h1>
+          <span class="highlight">CSS <code>accent-color</code></span>
+        </h1>
+        <p class="subtitle">
+          Easily customize the color of native form controls for a modern,
+          branded UI!
+        </p>
+      </header>
+      <section class="theory-section">
+        <h2>What is the <code>accent-color</code> Property?</h2>
+        <p>
+          The <strong>CSS <code>accent-color</code> property</strong> allows you
+          to set the accent color for form controls such as checkboxes, radio
+          buttons, range sliders, and progress bars. This makes it easy to match
+          native controls to your site's color scheme without complex custom
+          markup or JavaScript.
+        </p>
+        <ul class="theory-list">
+          <li>
+            <strong>Simple Customization:</strong> Change the accent color of
+            supported controls with a single line of CSS.
+          </li>
+          <li>
+            <strong>Native Look & Feel:</strong> Controls remain accessible and
+            keep their native behavior.
+          </li>
+          <li>
+            <strong>Wide Support:</strong> Works in all modern browsers for
+            checkboxes, radios, range, and progress.
+          </li>
+        </ul>
+        <div class="syntax-block">
+          <h3>Syntax</h3>
+          <pre><code>selector {
   accent-color: #4f8cff;
 }
                 </code></pre>
-            </div>
-            <div class="tip-block">
-                <span class="tip-icon">💡</span>
-                <span>
-                    <strong>Tip:</strong> Use CSS variables for easy theme switching and consistent branding!
-                </span>
-            </div>
-            <div class="note">
-                <strong>Browser Support:</strong> <code>accent-color</code> is supported in all modern browsers.
-            </div>
-        </section>
+        </div>
+        <div class="tip-block">
+          <span class="tip-icon">💡</span>
+          <span>
+            <strong>Tip:</strong> Use CSS variables for easy theme switching and
+            consistent branding!
+          </span>
+        </div>
+        <div class="note">
+          <strong>Browser Support:</strong> <code>accent-color</code> is
+          supported in all modern browsers.
+        </div>
+      </section>
 
-        <section class="examples-section">
-            <h2>Interactive Examples</h2>
-            <div class="example-grid">
-                <!-- Example 1: Checkbox and Radio -->
-                <div class="example-card">
-                    <h3>Custom Accent Checkbox & Radio</h3>
-                    <label>
-                        <input type="checkbox" class="accent-demo" checked>
-                        Checkbox
-                    </label>
-                    <label>
-                        <input type="radio" class="accent-demo" name="radio-demo" checked>
-                        Radio 1
-                    </label>
-                    <label>
-                        <input type="radio" class="accent-demo" name="radio-demo">
-                        Radio 2
-                    </label>
-                    <pre class="code-block" tabindex="0">
+      <section class="examples-section">
+        <h2>Interactive Examples</h2>
+        <div class="example-grid">
+          <!-- Example 1: Checkbox and Radio -->
+          <div class="example-card">
+            <h3>Custom Accent Checkbox & Radio</h3>
+            <label>
+              <input type="checkbox" class="accent-demo" checked />
+              Checkbox
+            </label>
+            <label>
+              <input
+                type="radio"
+                class="accent-demo"
+                name="radio-demo"
+                checked
+              />
+              Radio 1
+            </label>
+            <label>
+              <input type="radio" class="accent-demo" name="radio-demo" />
+              Radio 2
+            </label>
+            <pre class="code-block" tabindex="0">
 .accent-demo {
   accent-color: var(--color-accent, #4f8cff);
 }
-                    </pre>
-                </div>
-                <!-- Example 2: Range and Progress -->
-                <div class="example-card">
-                    <h3>Custom Accent Range & Progress</h3>
-                    <input type="range" class="accent-demo" min="0" max="100" value="60">
-                    <progress class="accent-demo" value="40" max="100"></progress>
-                    <pre class="code-block" tabindex="0">
+                    </pre
+            >
+          </div>
+          <!-- Example 2: Range and Progress -->
+          <div class="example-card">
+            <h3>Custom Accent Range & Progress</h3>
+            <label for="range-example">Custom Accent Range:</label>
+            <input
+              type="range"
+              class="accent-demo"
+              min="0"
+              max="100"
+              value="60"
+              id="range-example"
+            />
+            <label for="progress-example">Custom Accent Progress:</label>
+            <progress
+              class="accent-demo"
+              value="40"
+              max="100"
+              id="progress-example"
+            ></progress>
+            <pre class="code-block" tabindex="0">
 .accent-demo {
   accent-color: var(--color-accent, #4f8cff);
 }
-                    </pre>
-                </div>
-            </div>
-            <div class="note">
-                <strong>Try it:</strong> Interact with the controls above. The accent color is set using <code>accent-color</code> and can be easily themed!
-            </div>
-        </section>
+                    </pre
+            >
+          </div>
+        </div>
+        <div class="note">
+          <strong>Try it:</strong> Interact with the controls above. The accent
+          color is set using <code>accent-color</code> and can be easily themed!
+        </div>
+      </section>
 
-        <section class="references-section">
-            <h2>References</h2>
-            <ul>
-                <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color" target="_blank" rel="noopener">MDN: CSS accent-color</a></li>
-                <li><a href="https://css-tricks.com/css-accent-color/" target="_blank" rel="noopener">CSS-Tricks: accent-color</a></li>
-            </ul>
-        </section>
+      <section class="references-section">
+        <h2>References</h2>
+        <ul>
+          <li>
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color"
+              target="_blank"
+              rel="noopener"
+              >MDN: CSS accent-color</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://css-tricks.com/css-accent-color/"
+              target="_blank"
+              rel="noopener"
+              >CSS-Tricks: accent-color</a
+            >
+          </li>
+        </ul>
+      </section>
     </main>
-</body>
+  </body>
 </html>

--- a/HTML/accent-color.html
+++ b/HTML/accent-color.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="In-depth guide to the CSS accent-color property with interactive examples and best practices.">
+    <meta name="keywords" content="css, accent-color, form controls, css accent, css demo">
+    <meta name="author" content="Suraj Ingole">
+    <meta name="robots" content="index, follow">
+    <link rel="shortcut icon" href="../images/css_favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../CSS/accent-color.css">
+    <title>CSS accent-color – Theory & Interactive Examples</title>
+</head>
+<body>
+    <nav class="back-nav">
+        <a href="../index.html" class="back-btn">&larr; Back to Home</a>
+    </nav>
+    <main class="accent-main">
+        <header class="accent-header">
+            <h1><span class="highlight">CSS <code>accent-color</code></span></h1>
+            <p class="subtitle">Easily customize the color of native form controls for a modern, branded UI!</p>
+        </header>
+        <section class="theory-section">
+            <h2>What is the <code>accent-color</code> Property?</h2>
+            <p>
+                The <strong>CSS <code>accent-color</code> property</strong> allows you to set the accent color for form controls such as checkboxes, radio buttons, range sliders, and progress bars. This makes it easy to match native controls to your site's color scheme without complex custom markup or JavaScript.
+            </p>
+            <ul class="theory-list">
+                <li>
+                    <strong>Simple Customization:</strong> Change the accent color of supported controls with a single line of CSS.
+                </li>
+                <li>
+                    <strong>Native Look & Feel:</strong> Controls remain accessible and keep their native behavior.
+                </li>
+                <li>
+                    <strong>Wide Support:</strong> Works in all modern browsers for checkboxes, radios, range, and progress.
+                </li>
+            </ul>
+            <div class="syntax-block">
+                <h3>Syntax</h3>
+                <pre><code>selector {
+  accent-color: #4f8cff;
+}
+                </code></pre>
+            </div>
+            <div class="tip-block">
+                <span class="tip-icon">💡</span>
+                <span>
+                    <strong>Tip:</strong> Use CSS variables for easy theme switching and consistent branding!
+                </span>
+            </div>
+            <div class="note">
+                <strong>Browser Support:</strong> <code>accent-color</code> is supported in all modern browsers.
+            </div>
+        </section>
+
+        <section class="examples-section">
+            <h2>Interactive Examples</h2>
+            <div class="example-grid">
+                <!-- Example 1: Checkbox and Radio -->
+                <div class="example-card">
+                    <h3>Custom Accent Checkbox & Radio</h3>
+                    <label>
+                        <input type="checkbox" class="accent-demo" checked>
+                        Checkbox
+                    </label>
+                    <label>
+                        <input type="radio" class="accent-demo" name="radio-demo" checked>
+                        Radio 1
+                    </label>
+                    <label>
+                        <input type="radio" class="accent-demo" name="radio-demo">
+                        Radio 2
+                    </label>
+                    <pre class="code-block" tabindex="0">
+.accent-demo {
+  accent-color: var(--color-accent, #4f8cff);
+}
+                    </pre>
+                </div>
+                <!-- Example 2: Range and Progress -->
+                <div class="example-card">
+                    <h3>Custom Accent Range & Progress</h3>
+                    <input type="range" class="accent-demo" min="0" max="100" value="60">
+                    <progress class="accent-demo" value="40" max="100"></progress>
+                    <pre class="code-block" tabindex="0">
+.accent-demo {
+  accent-color: var(--color-accent, #4f8cff);
+}
+                    </pre>
+                </div>
+            </div>
+            <div class="note">
+                <strong>Try it:</strong> Interact with the controls above. The accent color is set using <code>accent-color</code> and can be easily themed!
+            </div>
+        </section>
+
+        <section class="references-section">
+            <h2>References</h2>
+            <ul>
+                <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color" target="_blank" rel="noopener">MDN: CSS accent-color</a></li>
+                <li><a href="https://css-tricks.com/css-accent-color/" target="_blank" rel="noopener">CSS-Tricks: accent-color</a></li>
+            </ul>
+        </section>
+    </main>
+</body>
+</html>

--- a/Summary.md
+++ b/Summary.md
@@ -57,6 +57,8 @@ Whether you're a beginner or an experienced developer, use this summary to quick
 - [CSS @Layer](#44-css-layer-cascade-layers)
 - [CSS All Property](#45-css-all-property)
 - [CSS Appearance Property](#46-css-appearance-property)
+- [CSS Accent Color Property](#47-css-accent-color-property)
+
 ---
 
 ## 1. What is CSS?
@@ -64,13 +66,15 @@ Whether you're a beginner or an experienced developer, use this summary to quick
 **CSS (Cascading Style Sheets)** is a style sheet language used to define the presentation and layout of HTML documents. It separates content (HTML) from design, enabling consistent styling across multiple web pages.
 
 ### 🔑 Key Concepts:
--
- **Separation of Concerns:** Structure (HTML) vs. Style (CSS)
+
+- **Separation of Concerns:** Structure (HTML) vs. Style (CSS)
+
 - **Cascading Nature:** Multiple rules can apply to an element; the most specific one takes effect.
+
 - **Inheritance:** Certain properties (e.g., `color`, `font-family`) pass from parent to child elements.
 
-
 ### ✅ Example:
+
 ```html
 <!-- index.html -->
 <!DOCTYPE html>
@@ -3196,3 +3200,138 @@ Always include the unprefixed `appearance` property as well for future compatibi
 -   CSS-Tricks: [`appearance`](https://css-tricks.com/almanac/properties/a/appearance/)
     
 -   Web.dev: [Customizing form controls](https://web.dev/customize-form-controls/) 
+
+
+## 47. CSS `accent-color` Property
+
+### What is the `accent-color` Property in CSS?
+
+The `accent-color` CSS property allows you to **tint the accent color of certain user-interface controls**, such as checkboxes, radio buttons, range sliders, and progress bars. Instead of relying on the browser's default blue or purple, `accent-color` provides a simple, direct way to match these native elements to your brand's color palette without resorting to complex custom styling.
+
+This property is a game-changer for theming and consistency, as it lets you style these elements with a single line of CSS, while still retaining their native accessibility and functionality.
+
+#### Example:
+
+HTML
+
+```html
+<label><input type="checkbox" class="my-checkbox"> Remember Me</label><br>
+<label><input type="radio" name="option" value="a" class="my-radio"> Option A</label><br>
+<label><input type="radio" name="option" value="b" class="my-radio"> Option B</label><br>
+<input type="range" min="0" max="100" value="50" class="my-range"><br>
+<progress value="70" max="100" class="my-progress"></progress>
+
+```
+
+CSS
+
+```css
+/* CSS */
+
+/* Global accent color for all supported controls */
+:root {
+  accent-color: #ff6347; /* Tomato red */
+}
+
+/* Or apply to specific elements or their parents */
+.my-checkbox {
+  accent-color: purple;
+}
+
+.my-radio {
+  accent-color: green;
+}
+
+.my-range {
+  accent-color: darkorange;
+}
+
+.my-progress {
+  accent-color: #007bff; /* Dodger Blue */
+}
+
+/* It also works with inherited values */
+.theme-container {
+  accent-color: #28a745; /* A green accent for everything inside */
+}
+
+```
+
+### How `accent-color` Works:
+
+The `accent-color` property accepts any valid CSS `<color>` value:
+
+-   Hex codes (e.g., `#ff6347`)
+    
+-   RGB/RGBA (e.g., `rgb(255, 99, 71)`)
+    
+-   HSL/HSLA (e.g., `hsl(9, 100%, 64%)`)
+    
+-   Named colors (e.g., `tomato`)
+    
+-   CSS Custom Properties (variables) (e.g., `var(--brand-color)`)
+    
+
+When applied, the browser takes this color and uses it to tint the relevant parts of the UI control, such as the checkmark of a checkbox, the dot of a radio button, the filled track of a range slider, or the progress bar fill. The browser often intelligently calculates a contrasting foreground color (e.g., white or black) for text or symbols that appear on top of the accent color to ensure readability.
+
+### Affected UI Elements:
+
+The `accent-color` property typically affects:
+
+-   `<input type="checkbox">`
+    
+-   `<input type="radio">`
+    
+-   `<input type="range">`
+    
+-   `<progress>`
+    
+-   `<input type="color">` (the color picker's selected color indicator)
+    
+-   `<input type="number">` (spinner arrows, though this can vary)
+    
+-   `<input type="date">`, `<input type="time">`, etc. (calendar/time picker highlight, again, browser dependent)
+    
+
+### 🔑 Key Points:
+
+-   **Simple Theming:** Provides an extremely easy way to brand native UI controls with just one line of CSS.
+    
+-   **Retains Native Behavior & Accessibility:** Unlike completely custom-styled controls (which often require `appearance: none;` and extensive manual styling), `accent-color` keeps the native interaction, keyboard navigation, and accessibility features of the elements.
+    
+-   **Automatic Contrast:** Browsers usually handle the contrast of text/symbols on top of the `accent-color` for you, improving accessibility.
+    
+-   **Inheritable:** Can be applied to parent elements (like `body` or `:root`) to apply a default accent color across many controls.
+    
+
+### Best Practices
+
+-   **Match Brand Colors:** Use your brand's primary or secondary colors for `accent-color` to maintain visual consistency.
+    
+-   **Consider Contrast:** While browsers try to ensure good contrast, always test your chosen `accent-color` against the default background colors of your controls to ensure readability for all users, especially those with low vision.
+    
+-   **Global vs. Specific:**
+    
+    -   Set a default on `:root` or `body` for site-wide consistency.
+        
+    -   Override it for specific components or sections if a different accent color is desired (e.g., an "error" form might use `red`).
+        
+-   **Progressive Enhancement:** `accent-color` is a modern feature. For older browsers, the native controls will simply revert to their default appearance, which is a graceful fallback. No complex fallbacks are typically needed.
+    
+
+### Compatibility
+
+-   **Excellent in modern browsers:** Widely supported in Chrome (93+), Edge (93+), Firefox (92+), Safari (15.5+).
+    
+-   No support in Internet Explorer.
+    
+-   Consider using it as a progressive enhancement, knowing that older browsers will simply show their default UI control colors.
+    
+
+### Further Reading
+
+-   MDN: [`accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color)
+    
+-   Web.dev: [Tinting your forms with `accent-color`](https://web.dev/accent-color/)
+    
+-   CSS-Tricks: [`accent-color`](https://css-tricks.com/almanac/properties/a/accent-color/)

--- a/Summary.md
+++ b/Summary.md
@@ -3215,11 +3215,11 @@ This property is a game-changer for theming and consistency, as it lets you styl
 HTML
 
 ```html
-<label><input type="checkbox" class="my-checkbox"> Remember Me</label><br>
-<label><input type="radio" name="option" value="a" class="my-radio"> Option A</label><br>
-<label><input type="radio" name="option" value="b" class="my-radio"> Option B</label><br>
-<input type="range" min="0" max="100" value="50" class="my-range"><br>
-<progress value="70" max="100" class="my-progress"></progress>
+<div><label for="my-checkbox">Remember Me</label><input type="checkbox" class="my-checkbox" id="my-checkbox"></div>
+<div><label for="option-a">Option A</label><input type="radio" name="option" value="a" class="my-radio" id="option-a"></div>
+<div><label for="option-b">Option B</label><input type="radio" name="option" value="b" class="my-radio" id="option-b"></div>
+<div><label for="my-range">Range:</label><input type="range" min="0" max="100" value="50" class="my-range" id="my-range"></div>
+<div><label for="my-progress">Progress:</label><progress value="70" max="100" class="my-progress" id="my-progress"></progress></div>
 
 ```
 

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
           <li><a href="HTML/css-@layer.html" target="_blank" rel="noopener noreferrer">CSS @layer</a></li>
           <li><a href="HTML/all-property.html" target="_blank" rel="noopener noreferrer">CSS All Property</a></li>
           <li><a href="HTML/appearance.html" target="_blank" rel="noopener noreferrer">CSS Appearance</a></li>
+          <li><a href="HTML/accent-color.html" target="_blank" rel="noopener noreferrer">CSS Accent Color</a></li>
         </ul>
       </section>
       <div class="section-divider"></div>


### PR DESCRIPTION
- Add new HTML page demonstrating CSS accent-color property with interactive examples.
- Include supporting CSS styles and update summary documentation.